### PR TITLE
chore/prettier and ci formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Run lint
         run: 'npm run lint'
 
+      - name: Run format check
+        run: 'npm run format'
+
       - name: Run build
         run: 'npm run build'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,21 @@
+# Build output
+dist/
+coverage/
+
+# Root *.json files
+*.json
+
+# Dependency lockfiles
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# Docs / meta
+README.md
+CHANGELOG.md
+
+# Generated / vendor
+node_modules/
+
+# Github workflows
+.github/

--- a/credentials/TanssApi.credentials.ts
+++ b/credentials/TanssApi.credentials.ts
@@ -1,9 +1,4 @@
-import {
-	Icon,
-	ICredentialType,
-	INodeProperties,
-	ICredentialTestRequest,
-} from 'n8n-workflow';
+import { Icon, ICredentialType, INodeProperties, ICredentialTestRequest } from 'n8n-workflow';
 
 export class TanssApi implements ICredentialType {
 	name = 'tanssApi';

--- a/nodes/tanss/Tanss.node.ts
+++ b/nodes/tanss/Tanss.node.ts
@@ -1,9 +1,18 @@
-import { INodeType, INodeTypeDescription, IExecuteFunctions, NodeOperationError } from 'n8n-workflow';
+import {
+	INodeType,
+	INodeTypeDescription,
+	IExecuteFunctions,
+	NodeOperationError,
+} from 'n8n-workflow';
 import { handleAuth, authOperations, authFields } from './sub/Authentication';
 import { handlePc, pcOperations, pcFields } from './sub/PCs';
 import { handleTicket, ticketOperations, ticketFields } from './sub/Tickets';
 import { handleTicketList, ticketListOperations, ticketListFields } from './sub/TicketLists';
-import { handleTicketContent, ticketContentOperations, ticketContentFields } from './sub/TicketContent';
+import {
+	handleTicketContent,
+	ticketContentOperations,
+	ticketContentFields,
+} from './sub/TicketContent';
 import { handleTicketStates, ticketStatesOperations, ticketStatesFields } from './sub/TicketSates';
 import { handleTimestamps, timestampOperations, timestampFields } from './sub/timestamp';
 import { handleAvailability, availabilityOperations, availabilityFields } from './sub/Availability';
@@ -11,11 +20,23 @@ import { handleEmployees, employeesOperations, employeesFields } from './sub/Emp
 import { handleMails, mailsOperations, mailsFields } from './sub/Mails';
 import { handleCalls, callsOperations, callsFields } from './sub/calls';
 import { handleCallsUser, callsUserOperations, callsUserFields } from './sub/callsuser';
-import { handleRemoteSupports, remoteSupportsOperations, remoteSupportsFields } from './sub/RemoteSupports';
+import {
+	handleRemoteSupports,
+	remoteSupportsOperations,
+	remoteSupportsFields,
+} from './sub/RemoteSupports';
 import { handleCpu, cpuOperations, cpuFields } from './sub/CPUs';
 import { handleHddTypes, hddTypesOperations, hddTypesFields } from './sub/hddTypes';
-import { handleManufacturers, manufacturersOperations, manufacturersFields } from './sub/manufacturers';
-import { handleOperatingSystems, operatingSystemsOperations, operatingSystemsFields } from './sub/OperatingSystems';
+import {
+	handleManufacturers,
+	manufacturersOperations,
+	manufacturersFields,
+} from './sub/manufacturers';
+import {
+	handleOperatingSystems,
+	operatingSystemsOperations,
+	operatingSystemsFields,
+} from './sub/OperatingSystems';
 
 export class Tanss implements INodeType {
 	description: INodeTypeDescription = {
@@ -105,7 +126,6 @@ export class Tanss implements INodeType {
 		],
 	};
 
-
 	async execute(this: IExecuteFunctions) {
 		const items = this.getInputData();
 		const returnData = [];
@@ -125,12 +145,17 @@ export class Tanss implements INodeType {
 			else if (resource === 'callsuser') responseData = await handleCallsUser.call(this, i);
 			else if (resource === 'employees') responseData = await handleEmployees.call(this, i);
 			else if (resource === 'mails') responseData = await handleMails.call(this, i);
-			else if (resource === 'remoteSupports') responseData = await handleRemoteSupports.call(this, i);
+			else if (resource === 'remoteSupports')
+				responseData = await handleRemoteSupports.call(this, i);
 			else if (resource === 'availability') responseData = await handleAvailability.call(this, i);
 			else if (resource === 'hddTypes') responseData = await handleHddTypes.call(this, i);
 			else if (resource === 'manufacturers') responseData = await handleManufacturers.call(this, i);
-			else if (resource === 'operatingSystems') responseData = await handleOperatingSystems.call(this, i);
-			else throw new NodeOperationError(this.getNode(), `Unknown resource: ${resource}`, { itemIndex: i });
+			else if (resource === 'operatingSystems')
+				responseData = await handleOperatingSystems.call(this, i);
+			else
+				throw new NodeOperationError(this.getNode(), `Unknown resource: ${resource}`, {
+					itemIndex: i,
+				});
 
 			if (Array.isArray(responseData)) returnData.push(...responseData);
 			else returnData.push(responseData);

--- a/nodes/tanss/sub/2fa.ts
+++ b/nodes/tanss/sub/2fa.ts
@@ -1,53 +1,53 @@
 import { createHmac } from 'crypto';
 
 function normalizeBase32Input(input: string): string {
-    if (!input) return '';
-    const uriMatch = input.match(/secret=([^&]+)/i);
-    if (uriMatch) input = decodeURIComponent(uriMatch[1]);
-    return input.replace(/[\s-]/g, '').replace(/=+$/, '').toUpperCase();
+	if (!input) return '';
+	const uriMatch = input.match(/secret=([^&]+)/i);
+	if (uriMatch) input = decodeURIComponent(uriMatch[1]);
+	return input.replace(/[\s-]/g, '').replace(/=+$/, '').toUpperCase();
 }
 
 function base32ToBuffer(base32: string): Buffer {
-    const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
-    let bits = '';
-    const bytes: number[] = [];
+	const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+	let bits = '';
+	const bytes: number[] = [];
 
-    base32 = normalizeBase32Input(base32);
+	base32 = normalizeBase32Input(base32);
 
-    for (const char of base32) {
-        const val = alphabet.indexOf(char);
-        if (val === -1) continue;
-        bits += val.toString(2).padStart(5, '0');
-    }
+	for (const char of base32) {
+		const val = alphabet.indexOf(char);
+		if (val === -1) continue;
+		bits += val.toString(2).padStart(5, '0');
+	}
 
-    for (let i = 0; i + 8 <= bits.length; i += 8) {
-        bytes.push(parseInt(bits.substring(i, i + 8), 2));
-    }
+	for (let i = 0; i + 8 <= bits.length; i += 8) {
+		bytes.push(parseInt(bits.substring(i, i + 8), 2));
+	}
 
-    return Buffer.from(bytes);
+	return Buffer.from(bytes);
 }
 
 export function generateTOTP(secret: string, window = 0): string {
-    if (!secret) {
-        throw new Error('No 2FA secret provided');
-    }
+	if (!secret) {
+		throw new Error('No 2FA secret provided');
+	}
 
-    const epoch = Math.floor(Date.now() / 1000);
-    const counter = Math.floor(epoch / 30) + window;
+	const epoch = Math.floor(Date.now() / 1000);
+	const counter = Math.floor(epoch / 30) + window;
 
-    const buffer = Buffer.alloc(8);
-    buffer.writeUInt32BE(0, 0);
-    buffer.writeUInt32BE(counter, 4);
+	const buffer = Buffer.alloc(8);
+	buffer.writeUInt32BE(0, 0);
+	buffer.writeUInt32BE(counter, 4);
 
-    const key = base32ToBuffer(secret);
-    const hmac = createHmac('sha1', key).update(buffer).digest();
+	const key = base32ToBuffer(secret);
+	const hmac = createHmac('sha1', key).update(buffer).digest();
 
-    const offset = hmac[hmac.length - 1] & 0xf;
-    const code =
-        ((hmac[offset] & 0x7f) << 24) |
-        ((hmac[offset + 1] & 0xff) << 16) |
-        ((hmac[offset + 2] & 0xff) << 8) |
-        (hmac[offset + 3] & 0xff);
+	const offset = hmac[hmac.length - 1] & 0xf;
+	const code =
+		((hmac[offset] & 0x7f) << 24) |
+		((hmac[offset + 1] & 0xff) << 16) |
+		((hmac[offset + 2] & 0xff) << 8) |
+		(hmac[offset + 3] & 0xff);
 
-    return (code % 1_000_000).toString().padStart(6, '0');
+	return (code % 1_000_000).toString().padStart(6, '0');
 }

--- a/nodes/tanss/sub/Authentication.ts
+++ b/nodes/tanss/sub/Authentication.ts
@@ -82,14 +82,19 @@ export async function handleAuth(this: IExecuteFunctions, i: number) {
 					const responseData = await this.helpers.httpRequest(requestOptions);
 					return responseData;
 				} catch (err: unknown) {
-					const e = err as { message?: string; status?: number; response?: { status?: number; data?: unknown } } | undefined;
+					const e = err as
+						| { message?: string; status?: number; response?: { status?: number; data?: unknown } }
+						| undefined;
 					lastError = err;
 
 					const responseData = e?.response?.data ?? e?.message ?? e;
 					const msg = JSON.stringify(responseData);
 
 					if (msg.includes('LOGIN_ERROR_TOO_MANY_FAILED_LOGINS')) {
-						throw new NodeOperationError(this.getNode(), `Login blocked: too many failed logins. Server response: ${msg}`);
+						throw new NodeOperationError(
+							this.getNode(),
+							`Login blocked: too many failed logins. Server response: ${msg}`,
+						);
 					}
 					if (!msg.includes('LOGIN_ERROR_WRONG_LOGIN_TOKEN_CODE')) {
 						throw new NodeOperationError(this.getNode(), `Login failed: ${msg}`);
@@ -97,7 +102,10 @@ export async function handleAuth(this: IExecuteFunctions, i: number) {
 				}
 			}
 
-			throw new NodeOperationError(this.getNode(), `Failed to login with generated TOTP after ${attempts} attempts. Last error: ${JSON.stringify(lastError)}`);
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to login with generated TOTP after ${attempts} attempts. Last error: ${JSON.stringify(lastError)}`,
+			);
 		}
 
 		try {

--- a/nodes/tanss/sub/Availability.ts
+++ b/nodes/tanss/sub/Availability.ts
@@ -1,82 +1,91 @@
 import { IExecuteFunctions, INodeProperties, NodeOperationError } from 'n8n-workflow';
 
 export const availabilityOperations: INodeProperties[] = [
-    {
-        displayName: 'Operation',
-        name: 'operation',
-        type: 'options' as const,
-        noDataExpression: true,
-        displayOptions: { show: { resource: ['availability'] } },
-        options: [
-            { name: 'Get Availability', value: 'getAvailability', description: 'Fetch availability information for employees', action: 'Get availability' },
-        ],
-        default: 'getAvailability',
-    },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options' as const,
+		noDataExpression: true,
+		displayOptions: { show: { resource: ['availability'] } },
+		options: [
+			{
+				name: 'Get Availability',
+				value: 'getAvailability',
+				description: 'Fetch availability information for employees',
+				action: 'Get availability',
+			},
+		],
+		default: 'getAvailability',
+	},
 ];
 
 export const availabilityFields: INodeProperties[] = [
-    {
-        displayName: 'API Token',
-        name: 'apiToken',
-        type: 'string' as const,
-        typeOptions: { password: true },
-        default: '',
-        description: 'API token obtained from the TANSS API login',
-        displayOptions: { show: { resource: ['availability'] } },
-    },
-    {
-        displayName: 'Employee IDs (Comma Separated)',
-        name: 'employeeIds',
-        type: 'string' as const,
-        required: true,
-        default: '',
-        description: 'Comma-separated list of employee IDs to fetch availability for',
-        displayOptions: { show: { resource: ['availability'], operation: ['getAvailability'] } },
-    },
+	{
+		displayName: 'API Token',
+		name: 'apiToken',
+		type: 'string' as const,
+		typeOptions: { password: true },
+		default: '',
+		description: 'API token obtained from the TANSS API login',
+		displayOptions: { show: { resource: ['availability'] } },
+	},
+	{
+		displayName: 'Employee IDs (Comma Separated)',
+		name: 'employeeIds',
+		type: 'string' as const,
+		required: true,
+		default: '',
+		description: 'Comma-separated list of employee IDs to fetch availability for',
+		displayOptions: { show: { resource: ['availability'], operation: ['getAvailability'] } },
+	},
 ];
 
 export async function handleAvailability(this: IExecuteFunctions, i: number) {
-    const credentials = await this.getCredentials('tanssApi');
-    if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
+	const credentials = await this.getCredentials('tanssApi');
+	if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
 
-    const apiToken = this.getNodeParameter('apiToken', i, '') as string;
-    const employeeIds = this.getNodeParameter('employeeIds', i) as string;
+	const apiToken = this.getNodeParameter('apiToken', i, '') as string;
+	const employeeIds = this.getNodeParameter('employeeIds', i) as string;
 
-    if (!employeeIds || String(employeeIds).trim() === '') {
-        throw new NodeOperationError(this.getNode(), 'employeeIds is required');
-    }
+	if (!employeeIds || String(employeeIds).trim() === '') {
+		throw new NodeOperationError(this.getNode(), 'employeeIds is required');
+	}
 
-    const base = credentials.baseURL as string;
-    if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
+	const base = credentials.baseURL as string;
+	if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
 
-    const url = `${base}/backend/api/v1/availability`;
+	const url = `${base}/backend/api/v1/availability`;
 
-    const requestOptions: {
-        method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-        headers: { [key: string]: string };
-        json: boolean;
-        url: string;
-    } = {
-        method: 'GET',
-        headers: { Accept: 'application/json' },
-        json: true,
-        url,
-    };
+	const requestOptions: {
+		method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+		headers: { [key: string]: string };
+		json: boolean;
+		url: string;
+	} = {
+		method: 'GET',
+		headers: { Accept: 'application/json' },
+		json: true,
+		url,
+	};
 
-    if (apiToken && String(apiToken).trim() !== '') {
-        const tokenValue = String(apiToken).startsWith('Bearer ') ? String(apiToken) : `Bearer ${String(apiToken)}`;
-        requestOptions.headers.Authorization = tokenValue;
-        requestOptions.headers.apiToken = tokenValue;
-    }
+	if (apiToken && String(apiToken).trim() !== '') {
+		const tokenValue = String(apiToken).startsWith('Bearer ')
+			? String(apiToken)
+			: `Bearer ${String(apiToken)}`;
+		requestOptions.headers.Authorization = tokenValue;
+		requestOptions.headers.apiToken = tokenValue;
+	}
 
-    const encoded = encodeURIComponent(String(employeeIds).trim());
-    requestOptions.url = `${url}?employeeIds=${encoded}`;
+	const encoded = encodeURIComponent(String(employeeIds).trim());
+	requestOptions.url = `${url}?employeeIds=${encoded}`;
 
-    try {
-        const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-        return response;
-    } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        throw new NodeOperationError(this.getNode(), `Failed to fetch availability: ${message}`);
-    }
+	try {
+		const response = await this.helpers.httpRequest(
+			requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+		);
+		return response;
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new NodeOperationError(this.getNode(), `Failed to fetch availability: ${message}`);
+	}
 }

--- a/nodes/tanss/sub/CPUs.ts
+++ b/nodes/tanss/sub/CPUs.ts
@@ -8,11 +8,36 @@ export const cpuOperations: INodeProperties[] = [
 		noDataExpression: true,
 		displayOptions: { show: { resource: ['cpus'] } },
 		options: [
-			{ name: 'Create CPU', value: 'createCpu', description: 'Creates a new CPU', action: 'Create a CPU' },
-			{ name: 'Delete CPU', value: 'deleteCpu', description: 'Deletes a CPU', action: 'Delete a CPU' },
-			{ name: 'Get All CPUs', value: 'getAllCpus', description: 'Gets a list of all CPUs', action: 'Get all CPUs' },
-			{ name: 'Get CPU', value: 'getCpuById', description: 'Gets a specific CPU', action: 'Get a CPU' },
-			{ name: 'Update CPU', value: 'updateCpu', description: 'Updates an existing CPU', action: 'Update a CPU' },
+			{
+				name: 'Create CPU',
+				value: 'createCpu',
+				description: 'Creates a new CPU',
+				action: 'Create a CPU',
+			},
+			{
+				name: 'Delete CPU',
+				value: 'deleteCpu',
+				description: 'Deletes a CPU',
+				action: 'Delete a CPU',
+			},
+			{
+				name: 'Get All CPUs',
+				value: 'getAllCpus',
+				description: 'Gets a list of all CPUs',
+				action: 'Get all CPUs',
+			},
+			{
+				name: 'Get CPU',
+				value: 'getCpuById',
+				description: 'Gets a specific CPU',
+				action: 'Get a CPU',
+			},
+			{
+				name: 'Update CPU',
+				value: 'updateCpu',
+				description: 'Updates an existing CPU',
+				action: 'Update a CPU',
+			},
 		],
 		default: 'getAllCpus',
 	},
@@ -35,7 +60,9 @@ export const cpuFields: INodeProperties[] = [
 		type: 'number' as const,
 		default: 0,
 		description: 'ID of the CPU',
-		displayOptions: { show: { resource: ['cpus'], operation: ['updateCpu','getCpuById','deleteCpu'] } },
+		displayOptions: {
+			show: { resource: ['cpus'], operation: ['updateCpu', 'getCpuById', 'deleteCpu'] },
+		},
 	},
 	{
 		displayName: 'Create CPU Fields',
@@ -90,8 +117,12 @@ export async function handleCpu(this: IExecuteFunctions, i: number) {
 		case 'createCpu': {
 			url = `${credentials.baseURL}/backend/api/v1/cpus`;
 			requestOptions.method = 'POST';
-			const createCpuFields = this.getNodeParameter('createCpuFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(createCpuFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields provided for CPU creation.');
+			const createCpuFields = this.getNodeParameter('createCpuFields', i, {}) as Record<
+				string,
+				unknown
+			>;
+			if (Object.keys(createCpuFields).length === 0)
+				throw new NodeOperationError(this.getNode(), 'No fields provided for CPU creation.');
 			requestOptions.body = createCpuFields;
 			break;
 		}
@@ -113,20 +144,30 @@ export async function handleCpu(this: IExecuteFunctions, i: number) {
 		case 'updateCpu': {
 			url = `${credentials.baseURL}/backend/api/v1/cpus/${cpuId}`;
 			requestOptions.method = 'PUT';
-			const updateCpuFields = this.getNodeParameter('updateCpuFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(updateCpuFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields provided for CPU update.');
+			const updateCpuFields = this.getNodeParameter('updateCpuFields', i, {}) as Record<
+				string,
+				unknown
+			>;
+			if (Object.keys(updateCpuFields).length === 0)
+				throw new NodeOperationError(this.getNode(), 'No fields provided for CPU update.');
 			requestOptions.body = updateCpuFields;
 			break;
 		}
 		default:
-			throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized for CPUs.`);
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized for CPUs.`,
+			);
 	}
 
 	requestOptions.url = url;
 
 	try {
 		type FullResponse = { statusCode: number; body?: unknown };
-		const options = { ...requestOptions, returnFullResponse: true } as unknown as import('n8n-workflow').IHttpRequestOptions;
+		const options = {
+			...requestOptions,
+			returnFullResponse: true,
+		} as unknown as import('n8n-workflow').IHttpRequestOptions;
 		const fullResponse = (await this.helpers.httpRequest(options)) as unknown as FullResponse;
 		if (requestOptions.method === 'DELETE') {
 			return { success: fullResponse.statusCode === 204, statusCode: fullResponse.statusCode };

--- a/nodes/tanss/sub/Employees.ts
+++ b/nodes/tanss/sub/Employees.ts
@@ -1,221 +1,317 @@
-import { IExecuteFunctions, INodeProperties, NodeOperationError, IDataObject, IHttpRequestOptions } from 'n8n-workflow';
+import {
+	IExecuteFunctions,
+	INodeProperties,
+	NodeOperationError,
+	IDataObject,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
 
 export const employeesOperations: INodeProperties[] = [
-    {
-        displayName: 'Operation',
-        name: 'operation',
-        type: 'options' as const,
-        noDataExpression: true,
-        displayOptions: { show: { resource: ['employees'] } },
-        options: [
-            { name: 'Get Technicians', value: 'getTechnicians', description: 'Gets all technicians of this system', action: 'Get technicians' },
-            { name: 'Create Employee', value: 'createEmployee', description: 'Creates a new employee', action: 'Create employee' },
-        ],
-        default: 'getTechnicians',
-    },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options' as const,
+		noDataExpression: true,
+		displayOptions: { show: { resource: ['employees'] } },
+		options: [
+			{
+				name: 'Get Technicians',
+				value: 'getTechnicians',
+				description: 'Gets all technicians of this system',
+				action: 'Get technicians',
+			},
+			{
+				name: 'Create Employee',
+				value: 'createEmployee',
+				description: 'Creates a new employee',
+				action: 'Create employee',
+			},
+		],
+		default: 'getTechnicians',
+	},
 ];
 
 export const employeesFields: INodeProperties[] = [
-    {
-        displayName: 'API Token',
-        name: 'apiToken',
-        type: 'string' as const,
-        typeOptions: { password: true },
-        default: '',
-        description: 'Optional API token (Bearer). If not provided the credentials are used.',
-        displayOptions: { show: { resource: ['employees'] } },
-    },
-    {
-        displayName: 'Freelancer Company ID',
-        name: 'freelancerCompanyId',
-        type: 'number' as const,
-        default: 0,
-        description: 'If set, also fetches freelancers of this company (0 for all freelancers)',
-        displayOptions: { show: { resource: ['employees'], operation: ['getTechnicians'] } },
-    },
+	{
+		displayName: 'API Token',
+		name: 'apiToken',
+		type: 'string' as const,
+		typeOptions: { password: true },
+		default: '',
+		description: 'Optional API token (Bearer). If not provided the credentials are used.',
+		displayOptions: { show: { resource: ['employees'] } },
+	},
+	{
+		displayName: 'Freelancer Company ID',
+		name: 'freelancerCompanyId',
+		type: 'number' as const,
+		default: 0,
+		description: 'If set, also fetches freelancers of this company (0 for all freelancers)',
+		displayOptions: { show: { resource: ['employees'], operation: ['getTechnicians'] } },
+	},
 
-    {
-        displayName: 'Employee Object',
-        name: 'employeeObject',
-        type: 'collection' as const,
-        placeholder: 'Add Field',
-        displayOptions: { show: { resource: ['employees'], operation: ['createEmployee'] } },
-        default: {},
-        options: [
-            { displayName: 'ID', name: 'id', type: 'number' as const, default: 0 },
-            { displayName: 'Name', name: 'name', type: 'string' as const, default: '' },
-            { displayName: 'First Name', name: 'firstName', type: 'string' as const, default: '' },
-            { displayName: 'Last Name', name: 'lastName', type: 'string' as const, default: '' },
-            { displayName: 'Salutation ID', name: 'salutationId', type: 'number' as const, default: 0 },
-            { displayName: 'Department ID', name: 'departmentId', type: 'number' as const, default: 0 },
-            { displayName: 'Room', name: 'room', type: 'string' as const, default: '' },
-            { displayName: 'Telephone Number', name: 'telephoneNumber', type: 'string' as const, default: '' },
-            { displayName: 'Email Address', name: 'emailAddress', type: 'string' as const, default: '' },
-            { displayName: 'Car ID', name: 'carId', type: 'number' as const, default: 0 },
-            { displayName: 'Mobile Phone', name: 'mobilePhone', type: 'string' as const, default: '' },
-            { displayName: 'Initials', name: 'initials', type: 'string' as const, default: '' },
-            { displayName: 'Working Hour Model ID', name: 'workingHourModelId', type: 'number' as const, default: 0 },
-            { displayName: 'Accounting Type ID', name: 'accountingTypeId', type: 'number' as const, default: 0 },
-            { displayName: 'Private Phone Number', name: 'privatePhoneNumber', type: 'string' as const, default: '' },
-            { displayName: 'Active', name: 'active', type: 'boolean' as const, default: true },
-            { displayName: 'ERP Number', name: 'erpNumber', type: 'string' as const, default: '' },
-            { displayName: 'Personal Fax Number', name: 'personalFaxNumber', type: 'string' as const, default: '' },
-            { displayName: 'Role', name: 'role', type: 'string' as const, default: '' },
-            { displayName: 'Title ID', name: 'titleId', type: 'number' as const, default: 0 },
-            { displayName: 'Language', name: 'language', type: 'string' as const, default: '' },
-            { displayName: 'Telephone Number Two', name: 'telephoneNumberTwo', type: 'string' as const, default: '' },
-            { displayName: 'Mobile Number Two', name: 'mobileNumberTwo', type: 'string' as const, default: '' },
-            { displayName: 'Restricted User License', name: 'restrictedUserLicense', type: 'boolean' as const, default: false },
-            { displayName: 'Birthday (YYYY-MM-DD)', name: 'birthday', type: 'string' as const, default: '' },
-            {
-                displayName: 'Company Assignments',
-                name: 'companyAssignments',
-                type: 'fixedCollection' as const,
-                typeOptions: { multipleValues: true },
-                placeholder: 'Add Field',
-                default: {},
-                options: [
-                    {
-                        displayName: 'Assignment',
-                        name: 'assignment',
-                        values: [
-                            { displayName: 'Company ID', name: 'companyId', type: 'number' as const, default: 0 },
-                        ],
-                    },
-                ],
-            },
-        ],
-    },
+	{
+		displayName: 'Employee Object',
+		name: 'employeeObject',
+		type: 'collection' as const,
+		placeholder: 'Add Field',
+		displayOptions: { show: { resource: ['employees'], operation: ['createEmployee'] } },
+		default: {},
+		options: [
+			{ displayName: 'ID', name: 'id', type: 'number' as const, default: 0 },
+			{ displayName: 'Name', name: 'name', type: 'string' as const, default: '' },
+			{ displayName: 'First Name', name: 'firstName', type: 'string' as const, default: '' },
+			{ displayName: 'Last Name', name: 'lastName', type: 'string' as const, default: '' },
+			{ displayName: 'Salutation ID', name: 'salutationId', type: 'number' as const, default: 0 },
+			{ displayName: 'Department ID', name: 'departmentId', type: 'number' as const, default: 0 },
+			{ displayName: 'Room', name: 'room', type: 'string' as const, default: '' },
+			{
+				displayName: 'Telephone Number',
+				name: 'telephoneNumber',
+				type: 'string' as const,
+				default: '',
+			},
+			{ displayName: 'Email Address', name: 'emailAddress', type: 'string' as const, default: '' },
+			{ displayName: 'Car ID', name: 'carId', type: 'number' as const, default: 0 },
+			{ displayName: 'Mobile Phone', name: 'mobilePhone', type: 'string' as const, default: '' },
+			{ displayName: 'Initials', name: 'initials', type: 'string' as const, default: '' },
+			{
+				displayName: 'Working Hour Model ID',
+				name: 'workingHourModelId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Accounting Type ID',
+				name: 'accountingTypeId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Private Phone Number',
+				name: 'privatePhoneNumber',
+				type: 'string' as const,
+				default: '',
+			},
+			{ displayName: 'Active', name: 'active', type: 'boolean' as const, default: true },
+			{ displayName: 'ERP Number', name: 'erpNumber', type: 'string' as const, default: '' },
+			{
+				displayName: 'Personal Fax Number',
+				name: 'personalFaxNumber',
+				type: 'string' as const,
+				default: '',
+			},
+			{ displayName: 'Role', name: 'role', type: 'string' as const, default: '' },
+			{ displayName: 'Title ID', name: 'titleId', type: 'number' as const, default: 0 },
+			{ displayName: 'Language', name: 'language', type: 'string' as const, default: '' },
+			{
+				displayName: 'Telephone Number Two',
+				name: 'telephoneNumberTwo',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Mobile Number Two',
+				name: 'mobileNumberTwo',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Restricted User License',
+				name: 'restrictedUserLicense',
+				type: 'boolean' as const,
+				default: false,
+			},
+			{
+				displayName: 'Birthday (YYYY-MM-DD)',
+				name: 'birthday',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Company Assignments',
+				name: 'companyAssignments',
+				type: 'fixedCollection' as const,
+				typeOptions: { multipleValues: true },
+				placeholder: 'Add Field',
+				default: {},
+				options: [
+					{
+						displayName: 'Assignment',
+						name: 'assignment',
+						values: [
+							{ displayName: 'Company ID', name: 'companyId', type: 'number' as const, default: 0 },
+						],
+					},
+				],
+			},
+		],
+	},
 ];
 
 export async function handleEmployees(this: IExecuteFunctions, i: number) {
-    const operation = this.getNodeParameter('operation', i) as string;
-    const credentials = await this.getCredentials('tanssApi');
-    if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
+	const operation = this.getNodeParameter('operation', i) as string;
+	const credentials = await this.getCredentials('tanssApi');
+	if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
 
-    const apiToken = this.getNodeParameter('apiToken', i, '') as string;
-    const base = credentials.baseURL as string;
-    if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
+	const apiToken = this.getNodeParameter('apiToken', i, '') as string;
+	const base = credentials.baseURL as string;
+	if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
 
-    const requestOptions: {
-        method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-        headers: { [key: string]: string };
-        json: boolean;
-        body?: IDataObject;
-        url: string;
-    } = {
-        method: 'GET',
-        headers: { Accept: 'application/json' },
-        json: true,
-        url: '',
-    };
+	const requestOptions: {
+		method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+		headers: { [key: string]: string };
+		json: boolean;
+		body?: IDataObject;
+		url: string;
+	} = {
+		method: 'GET',
+		headers: { Accept: 'application/json' },
+		json: true,
+		url: '',
+	};
 
-    if (apiToken && apiToken.toString().trim() !== '') {
-        const tokenValue = String(apiToken).startsWith('Bearer ') ? String(apiToken) : `Bearer ${String(apiToken)}`;
-        requestOptions.headers.Authorization = tokenValue;
-        requestOptions.headers.apiToken = tokenValue;
-    }
+	if (apiToken && apiToken.toString().trim() !== '') {
+		const tokenValue = String(apiToken).startsWith('Bearer ')
+			? String(apiToken)
+			: `Bearer ${String(apiToken)}`;
+		requestOptions.headers.Authorization = tokenValue;
+		requestOptions.headers.apiToken = tokenValue;
+	}
 
-    switch (operation) {
-        case 'getTechnicians': {
-            const freelancerCompanyId = Number(this.getNodeParameter('freelancerCompanyId', i, 0)) || 0;
-            let url = `${base}/backend/api/v1/employees/technicians`;
-            if (freelancerCompanyId > 0) {
-                url += `?freelancerCompanyId=${encodeURIComponent(String(freelancerCompanyId))}`;
-            }
-            requestOptions.method = 'GET';
-            requestOptions.url = url;
-            delete requestOptions.headers['Content-Type'];
-            break;
-        }
+	switch (operation) {
+		case 'getTechnicians': {
+			const freelancerCompanyId = Number(this.getNodeParameter('freelancerCompanyId', i, 0)) || 0;
+			let url = `${base}/backend/api/v1/employees/technicians`;
+			if (freelancerCompanyId > 0) {
+				url += `?freelancerCompanyId=${encodeURIComponent(String(freelancerCompanyId))}`;
+			}
+			requestOptions.method = 'GET';
+			requestOptions.url = url;
+			delete requestOptions.headers['Content-Type'];
+			break;
+		}
 
-        case 'createEmployee': {
-            const fields = this.getNodeParameter('employeeObject', i, {}) as IDataObject;
-            const body: IDataObject = {};
+		case 'createEmployee': {
+			const fields = this.getNodeParameter('employeeObject', i, {}) as IDataObject;
+			const body: IDataObject = {};
 
-            if (fields.id !== undefined && String(fields.id).trim() !== '') body.id = Number(fields.id) || 0;
-            if (fields.name && String(fields.name).trim() !== '') body.name = String(fields.name).trim();
-            if (fields.firstName && String(fields.firstName).trim() !== '') body.firstName = String(fields.firstName).trim();
-            if (fields.lastName && String(fields.lastName).trim() !== '') body.lastName = String(fields.lastName).trim();
-            if (fields.salutationId !== undefined && String(fields.salutationId).trim() !== '') body.salutationId = Number(fields.salutationId) || 0;
-            if (fields.departmentId !== undefined && String(fields.departmentId).trim() !== '') body.departmentId = Number(fields.departmentId) || 0;
-            if (fields.room && String(fields.room).trim() !== '') body.room = String(fields.room).trim();
-            if (fields.telephoneNumber && String(fields.telephoneNumber).trim() !== '') body.telephoneNumber = String(fields.telephoneNumber).trim();
-            if (fields.emailAddress && String(fields.emailAddress).trim() !== '') body.emailAddress = String(fields.emailAddress).trim();
-            if (fields.carId !== undefined && String(fields.carId).trim() !== '') body.carId = Number(fields.carId) || 0;
-            if (fields.mobilePhone && String(fields.mobilePhone).trim() !== '') body.mobilePhone = String(fields.mobilePhone).trim();
-            if (fields.initials && String(fields.initials).trim() !== '') body.initials = String(fields.initials).trim();
-            if (fields.workingHourModelId !== undefined && String(fields.workingHourModelId).trim() !== '') body.workingHourModelId = Number(fields.workingHourModelId) || 0;
-            if (fields.accountingTypeId !== undefined && String(fields.accountingTypeId).trim() !== '') body.accountingTypeId = Number(fields.accountingTypeId) || 0;
-            if (fields.privatePhoneNumber && String(fields.privatePhoneNumber).trim() !== '') body.privatePhoneNumber = String(fields.privatePhoneNumber).trim();
-            if (fields.active !== undefined) body.active = Boolean(fields.active);
-            if (fields.erpNumber && String(fields.erpNumber).trim() !== '') body.erpNumber = String(fields.erpNumber).trim();
-            if (fields.personalFaxNumber && String(fields.personalFaxNumber).trim() !== '') body.personalFaxNumber = String(fields.personalFaxNumber).trim();
-            if (fields.role && String(fields.role).trim() !== '') body.role = String(fields.role).trim();
-            if (fields.titleId !== undefined && String(fields.titleId).trim() !== '') body.titleId = Number(fields.titleId) || 0;
-            if (fields.language && String(fields.language).trim() !== '') body.language = String(fields.language).trim();
-            if (fields.telephoneNumberTwo && String(fields.telephoneNumberTwo).trim() !== '') body.telephoneNumberTwo = String(fields.telephoneNumberTwo).trim();
-            if (fields.mobileNumberTwo && String(fields.mobileNumberTwo).trim() !== '') body.mobileNumberTwo = String(fields.mobileNumberTwo).trim();
-            if (fields.restrictedUserLicense !== undefined) body.restrictedUserLicense = Boolean(fields.restrictedUserLicense);
-            if (fields.birthday && String(fields.birthday).trim() !== '') body.birthday = String(fields.birthday).trim();
+			if (fields.id !== undefined && String(fields.id).trim() !== '')
+				body.id = Number(fields.id) || 0;
+			if (fields.name && String(fields.name).trim() !== '') body.name = String(fields.name).trim();
+			if (fields.firstName && String(fields.firstName).trim() !== '')
+				body.firstName = String(fields.firstName).trim();
+			if (fields.lastName && String(fields.lastName).trim() !== '')
+				body.lastName = String(fields.lastName).trim();
+			if (fields.salutationId !== undefined && String(fields.salutationId).trim() !== '')
+				body.salutationId = Number(fields.salutationId) || 0;
+			if (fields.departmentId !== undefined && String(fields.departmentId).trim() !== '')
+				body.departmentId = Number(fields.departmentId) || 0;
+			if (fields.room && String(fields.room).trim() !== '') body.room = String(fields.room).trim();
+			if (fields.telephoneNumber && String(fields.telephoneNumber).trim() !== '')
+				body.telephoneNumber = String(fields.telephoneNumber).trim();
+			if (fields.emailAddress && String(fields.emailAddress).trim() !== '')
+				body.emailAddress = String(fields.emailAddress).trim();
+			if (fields.carId !== undefined && String(fields.carId).trim() !== '')
+				body.carId = Number(fields.carId) || 0;
+			if (fields.mobilePhone && String(fields.mobilePhone).trim() !== '')
+				body.mobilePhone = String(fields.mobilePhone).trim();
+			if (fields.initials && String(fields.initials).trim() !== '')
+				body.initials = String(fields.initials).trim();
+			if (
+				fields.workingHourModelId !== undefined &&
+				String(fields.workingHourModelId).trim() !== ''
+			)
+				body.workingHourModelId = Number(fields.workingHourModelId) || 0;
+			if (fields.accountingTypeId !== undefined && String(fields.accountingTypeId).trim() !== '')
+				body.accountingTypeId = Number(fields.accountingTypeId) || 0;
+			if (fields.privatePhoneNumber && String(fields.privatePhoneNumber).trim() !== '')
+				body.privatePhoneNumber = String(fields.privatePhoneNumber).trim();
+			if (fields.active !== undefined) body.active = Boolean(fields.active);
+			if (fields.erpNumber && String(fields.erpNumber).trim() !== '')
+				body.erpNumber = String(fields.erpNumber).trim();
+			if (fields.personalFaxNumber && String(fields.personalFaxNumber).trim() !== '')
+				body.personalFaxNumber = String(fields.personalFaxNumber).trim();
+			if (fields.role && String(fields.role).trim() !== '') body.role = String(fields.role).trim();
+			if (fields.titleId !== undefined && String(fields.titleId).trim() !== '')
+				body.titleId = Number(fields.titleId) || 0;
+			if (fields.language && String(fields.language).trim() !== '')
+				body.language = String(fields.language).trim();
+			if (fields.telephoneNumberTwo && String(fields.telephoneNumberTwo).trim() !== '')
+				body.telephoneNumberTwo = String(fields.telephoneNumberTwo).trim();
+			if (fields.mobileNumberTwo && String(fields.mobileNumberTwo).trim() !== '')
+				body.mobileNumberTwo = String(fields.mobileNumberTwo).trim();
+			if (fields.restrictedUserLicense !== undefined)
+				body.restrictedUserLicense = Boolean(fields.restrictedUserLicense);
+			if (fields.birthday && String(fields.birthday).trim() !== '')
+				body.birthday = String(fields.birthday).trim();
 
-            if (fields.companyAssignments) {
-                const raw = fields.companyAssignments as unknown;
-                const assignments: IDataObject[] = [];
+			if (fields.companyAssignments) {
+				const raw = fields.companyAssignments as unknown;
+				const assignments: IDataObject[] = [];
 
-                if (Array.isArray(raw)) {
-                    for (const item of raw as unknown[]) {
-                        const obj = item as IDataObject;
-                        if (obj && obj.assignment) {
-                            if (Array.isArray(obj.assignment)) {
-                                for (const a of obj.assignment as unknown[]) {
-                                    const ai = a as IDataObject;
-                                    if (ai && ai.companyId !== undefined) assignments.push({ companyId: Number(String(ai.companyId)) || 0 });
-                                }
-                            } else {
-                                const ai = obj.assignment as IDataObject;
-                                if (ai && ai.companyId !== undefined) assignments.push({ companyId: Number(String(ai.companyId)) || 0 });
-                            }
-                        } else if (obj && obj.companyId !== undefined) {
-                            assignments.push({ companyId: Number(String(obj.companyId)) || 0 });
-                        }
-                    }
-                } else if (typeof raw === 'object' && raw !== null) {
-                    const obj = raw as IDataObject;
-                    if (obj.assignment) {
-                        if (Array.isArray(obj.assignment)) {
-                            for (const a of obj.assignment as unknown[]) {
-                                const ai = a as IDataObject;
-                                if (ai && ai.companyId !== undefined) assignments.push({ companyId: Number(String(ai.companyId)) || 0 });
-                            }
-                        } else {
-                            const ai = obj.assignment as IDataObject;
-                            if (ai && ai.companyId !== undefined) assignments.push({ companyId: Number(String(ai.companyId)) || 0 });
-                        }
-                    } else if (obj.companyId !== undefined) {
-                        assignments.push({ companyId: Number(String(obj.companyId)) || 0 });
-                    }
-                }
+				if (Array.isArray(raw)) {
+					for (const item of raw as unknown[]) {
+						const obj = item as IDataObject;
+						if (obj && obj.assignment) {
+							if (Array.isArray(obj.assignment)) {
+								for (const a of obj.assignment as unknown[]) {
+									const ai = a as IDataObject;
+									if (ai && ai.companyId !== undefined)
+										assignments.push({ companyId: Number(String(ai.companyId)) || 0 });
+								}
+							} else {
+								const ai = obj.assignment as IDataObject;
+								if (ai && ai.companyId !== undefined)
+									assignments.push({ companyId: Number(String(ai.companyId)) || 0 });
+							}
+						} else if (obj && obj.companyId !== undefined) {
+							assignments.push({ companyId: Number(String(obj.companyId)) || 0 });
+						}
+					}
+				} else if (typeof raw === 'object' && raw !== null) {
+					const obj = raw as IDataObject;
+					if (obj.assignment) {
+						if (Array.isArray(obj.assignment)) {
+							for (const a of obj.assignment as unknown[]) {
+								const ai = a as IDataObject;
+								if (ai && ai.companyId !== undefined)
+									assignments.push({ companyId: Number(String(ai.companyId)) || 0 });
+							}
+						} else {
+							const ai = obj.assignment as IDataObject;
+							if (ai && ai.companyId !== undefined)
+								assignments.push({ companyId: Number(String(ai.companyId)) || 0 });
+						}
+					} else if (obj.companyId !== undefined) {
+						assignments.push({ companyId: Number(String(obj.companyId)) || 0 });
+					}
+				}
 
-                if (assignments.length) body.companyAssignments = assignments;
-            }
+				if (assignments.length) body.companyAssignments = assignments;
+			}
 
-            requestOptions.method = 'POST';
-            requestOptions.url = `${base}/backend/api/v1/employees`;
-            requestOptions.headers['Content-Type'] = 'application/json';
-            requestOptions.body = body;
-            break;
-        }
+			requestOptions.method = 'POST';
+			requestOptions.url = `${base}/backend/api/v1/employees`;
+			requestOptions.headers['Content-Type'] = 'application/json';
+			requestOptions.body = body;
+			break;
+		}
 
-        default:
-            throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized.`);
-    }
+		default:
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized.`,
+			);
+	}
 
-    try {
-    const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-        return response;
-    } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        throw new NodeOperationError(this.getNode(), `Failed to execute ${operation}: ${message}`);
-    }
+	try {
+		const response = await this.helpers.httpRequest(
+			requestOptions as unknown as IHttpRequestOptions,
+		);
+		return response;
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new NodeOperationError(this.getNode(), `Failed to execute ${operation}: ${message}`);
+	}
 }

--- a/nodes/tanss/sub/Mails.ts
+++ b/nodes/tanss/sub/Mails.ts
@@ -1,134 +1,192 @@
-import { IExecuteFunctions, INodeProperties, NodeOperationError, IDataObject, IHttpRequestOptions } from 'n8n-workflow';
+import {
+	IExecuteFunctions,
+	INodeProperties,
+	NodeOperationError,
+	IDataObject,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
 
 export const mailsOperations: INodeProperties[] = [
-    {
-        displayName: 'Operation',
-        name: 'operation',
-        type: 'options' as const,
-        noDataExpression: true,
-        displayOptions: { show: { resource: ['mails'] } },
-        options: [
-            { name: 'Test SMTP Settings', value: 'testSmtp', description: 'Send a test email using specified SMTP settings', action: 'Test SMTP' },
-        ],
-        default: 'testSmtp',
-    },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options' as const,
+		noDataExpression: true,
+		displayOptions: { show: { resource: ['mails'] } },
+		options: [
+			{
+				name: 'Test SMTP Settings',
+				value: 'testSmtp',
+				description: 'Send a test email using specified SMTP settings',
+				action: 'Test SMTP',
+			},
+		],
+		default: 'testSmtp',
+	},
 ];
 
 export const mailsFields: INodeProperties[] = [
-    {
-        displayName: 'API Token',
-        name: 'apiToken',
-        type: 'string' as const,
-        required: true,
-        typeOptions: { password: true },
-        default: '',
-        description: 'API token obtained from the TANSS web interface (must be generated in TANSS)',
-        displayOptions: { show: { resource: ['mails'] } },
-    },
-    {
-        displayName: 'Receiver',
-        name: 'receiver',
-        type: 'string' as const,
-        required: true,
-        default: '',
-        description: 'Receiver of the test message',
-        displayOptions: { show: { resource: ['mails'], operation: ['testSmtp'] } },
-    },
-    {
-        displayName: 'Email Settings',
-        name: 'mailObject',
-        type: 'collection' as const,
-        placeholder: 'Add Field',
-        displayOptions: { show: { resource: ['mails'], operation: ['testSmtp'] } },
-        default: {},
-        options: [
-            { displayName: 'SMTP Address', name: 'smtpAddress', type: 'string' as const, default: '' },
-            { displayName: 'SMTP Host', name: 'smtpHost', type: 'string' as const, default: '' },
-            { displayName: 'SMTP User', name: 'smtpUser', type: 'string' as const, default: '' },
-            { displayName: 'SMTP Password', name: 'smtpPassword', type: 'string' as const, default: '', typeOptions: { password: true } },
-            { displayName: 'SMTP Auth', name: 'smtpAuth', type: 'boolean' as const, default: false },
-            { displayName: 'SMTP Encryption Type', name: 'smtpEncryptionType', type: 'options' as const, default: 'NONE', options: [
-                { name: 'NONE', value: 'NONE' },
-                { name: 'SSL', value: 'SSL' },
-                { name: 'TLS', value: 'TLS' },
-            ] },
-            { displayName: 'SMTP Sender Name', name: 'smtpSenderName', type: 'string' as const, default: '' },
-        ],
-    },
+	{
+		displayName: 'API Token',
+		name: 'apiToken',
+		type: 'string' as const,
+		required: true,
+		typeOptions: { password: true },
+		default: '',
+		description: 'API token obtained from the TANSS web interface (must be generated in TANSS)',
+		displayOptions: { show: { resource: ['mails'] } },
+	},
+	{
+		displayName: 'Receiver',
+		name: 'receiver',
+		type: 'string' as const,
+		required: true,
+		default: '',
+		description: 'Receiver of the test message',
+		displayOptions: { show: { resource: ['mails'], operation: ['testSmtp'] } },
+	},
+	{
+		displayName: 'Email Settings',
+		name: 'mailObject',
+		type: 'collection' as const,
+		placeholder: 'Add Field',
+		displayOptions: { show: { resource: ['mails'], operation: ['testSmtp'] } },
+		default: {},
+		options: [
+			{ displayName: 'SMTP Address', name: 'smtpAddress', type: 'string' as const, default: '' },
+			{ displayName: 'SMTP Host', name: 'smtpHost', type: 'string' as const, default: '' },
+			{ displayName: 'SMTP User', name: 'smtpUser', type: 'string' as const, default: '' },
+			{
+				displayName: 'SMTP Password',
+				name: 'smtpPassword',
+				type: 'string' as const,
+				default: '',
+				typeOptions: { password: true },
+			},
+			{ displayName: 'SMTP Auth', name: 'smtpAuth', type: 'boolean' as const, default: false },
+			{
+				displayName: 'SMTP Encryption Type',
+				name: 'smtpEncryptionType',
+				type: 'options' as const,
+				default: 'NONE',
+				options: [
+					{ name: 'NONE', value: 'NONE' },
+					{ name: 'SSL', value: 'SSL' },
+					{ name: 'TLS', value: 'TLS' },
+				],
+			},
+			{
+				displayName: 'SMTP Sender Name',
+				name: 'smtpSenderName',
+				type: 'string' as const,
+				default: '',
+			},
+		],
+	},
 ];
 
 export async function handleMails(this: IExecuteFunctions, i: number) {
-    const operation = this.getNodeParameter('operation', i) as string;
-    const credentials = await this.getCredentials('tanssApi');
-    if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
+	const operation = this.getNodeParameter('operation', i) as string;
+	const credentials = await this.getCredentials('tanssApi');
+	if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
 
-    const apiToken = this.getNodeParameter('apiToken', i, '') as string;
-    const receiver = this.getNodeParameter('receiver', i, '') as string;
-    if (!receiver || String(receiver).trim() === '') throw new NodeOperationError(this.getNode(), 'receiver is required');
+	const apiToken = this.getNodeParameter('apiToken', i, '') as string;
+	const receiver = this.getNodeParameter('receiver', i, '') as string;
+	if (!receiver || String(receiver).trim() === '')
+		throw new NodeOperationError(this.getNode(), 'receiver is required');
 
-    const base = credentials.baseURL as string;
-    if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
+	const base = credentials.baseURL as string;
+	if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
 
-    const requestOptions: {
-        method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-        headers: { [key: string]: string };
-        json: boolean;
-        body?: IDataObject;
-        url: string;
-    } = {
-        method: 'POST',
-        headers: { Accept: 'application/json' },
-        json: true,
-        url: '',
-    };
+	const requestOptions: {
+		method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+		headers: { [key: string]: string };
+		json: boolean;
+		body?: IDataObject;
+		url: string;
+	} = {
+		method: 'POST',
+		headers: { Accept: 'application/json' },
+		json: true,
+		url: '',
+	};
 
-    if (apiToken && apiToken.toString().trim() !== '') {
-        const tokenValue = String(apiToken).startsWith('Bearer ') ? String(apiToken) : `Bearer ${String(apiToken)}`;
-        requestOptions.headers.Authorization = tokenValue;
-        requestOptions.headers.apiToken = tokenValue;
-    }
+	if (apiToken && apiToken.toString().trim() !== '') {
+		const tokenValue = String(apiToken).startsWith('Bearer ')
+			? String(apiToken)
+			: `Bearer ${String(apiToken)}`;
+		requestOptions.headers.Authorization = tokenValue;
+		requestOptions.headers.apiToken = tokenValue;
+	}
 
-    switch (operation) {
-        case 'testSmtp': {
-            const fields = this.getNodeParameter('mailObject', i, {}) as IDataObject;
-            const body: IDataObject = {};
+	switch (operation) {
+		case 'testSmtp': {
+			const fields = this.getNodeParameter('mailObject', i, {}) as IDataObject;
+			const body: IDataObject = {};
 
-            if (fields.smtpAddress && String(fields.smtpAddress).trim() !== '') body.smtpAddress = String(fields.smtpAddress).trim();
-            if (fields.smtpHost && String(fields.smtpHost).trim() !== '') body.smtpHost = String(fields.smtpHost).trim();
-            if (fields.smtpUser && String(fields.smtpUser).trim() !== '') body.smtpUser = String(fields.smtpUser).trim();
-            if (fields.smtpPassword && String(fields.smtpPassword).trim() !== '') body.smtpPassword = String(fields.smtpPassword).trim();
-            if (fields.smtpAuth !== undefined) body.smtpAuth = Boolean(fields.smtpAuth);
-            if (fields.smtpEncryptionType && String(fields.smtpEncryptionType).trim() !== '') body.smtpEncryptionType = String(fields.smtpEncryptionType).trim();
-            if (fields.smtpSenderName && String(fields.smtpSenderName).trim() !== '') body.smtpSenderName = String(fields.smtpSenderName).trim();
+			if (fields.smtpAddress && String(fields.smtpAddress).trim() !== '')
+				body.smtpAddress = String(fields.smtpAddress).trim();
+			if (fields.smtpHost && String(fields.smtpHost).trim() !== '')
+				body.smtpHost = String(fields.smtpHost).trim();
+			if (fields.smtpUser && String(fields.smtpUser).trim() !== '')
+				body.smtpUser = String(fields.smtpUser).trim();
+			if (fields.smtpPassword && String(fields.smtpPassword).trim() !== '')
+				body.smtpPassword = String(fields.smtpPassword).trim();
+			if (fields.smtpAuth !== undefined) body.smtpAuth = Boolean(fields.smtpAuth);
+			if (fields.smtpEncryptionType && String(fields.smtpEncryptionType).trim() !== '')
+				body.smtpEncryptionType = String(fields.smtpEncryptionType).trim();
+			if (fields.smtpSenderName && String(fields.smtpSenderName).trim() !== '')
+				body.smtpSenderName = String(fields.smtpSenderName).trim();
 
-            const url = `${base}/backend/api/v1/mails/test/smtp?receiver=${encodeURIComponent(String(receiver))}`;
-            requestOptions.method = 'POST';
-            requestOptions.url = url;
-            requestOptions.headers['Content-Type'] = 'application/json';
-            requestOptions.body = body;
-            break;
-        }
+			const url = `${base}/backend/api/v1/mails/test/smtp?receiver=${encodeURIComponent(String(receiver))}`;
+			requestOptions.method = 'POST';
+			requestOptions.url = url;
+			requestOptions.headers['Content-Type'] = 'application/json';
+			requestOptions.body = body;
+			break;
+		}
 
-        default:
-            throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized.`);
-    }
+		default:
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized.`,
+			);
+	}
 
-    try {
-    const fullResponse = await this.helpers.httpRequest({ ...(requestOptions as unknown as IDataObject), simple: false, resolveWithFullResponse: true } as unknown as IHttpRequestOptions);
-        if (fullResponse && fullResponse.statusCode === 201) {
-            return { success: true, statusCode: 201, message: 'Test email sent', body: fullResponse.body } as unknown as IDataObject;
-        }
-        if (fullResponse && fullResponse.statusCode === 500) {
-            return { success: false, statusCode: 500, message: 'Server error while sending test email', body: fullResponse.body } as unknown as IDataObject;
-        }
-        return fullResponse && fullResponse.body ? fullResponse.body : fullResponse;
-    } catch (err: unknown) {
-        const e = err as unknown as { statusCode?: number; response?: { statusCode?: number } };
-        const status = e?.statusCode ?? e?.response?.statusCode;
-        if (status === 500) {
-            return { success: false, statusCode: 500, message: 'Server error while sending test email' } as unknown as IDataObject;
-        }
-        const msg = err instanceof Error ? err.message : String(err);
-        throw new NodeOperationError(this.getNode(), `Failed to execute ${operation}: ${msg}`);
-    }
+	try {
+		const fullResponse = await this.helpers.httpRequest({
+			...(requestOptions as unknown as IDataObject),
+			simple: false,
+			resolveWithFullResponse: true,
+		} as unknown as IHttpRequestOptions);
+		if (fullResponse && fullResponse.statusCode === 201) {
+			return {
+				success: true,
+				statusCode: 201,
+				message: 'Test email sent',
+				body: fullResponse.body,
+			} as unknown as IDataObject;
+		}
+		if (fullResponse && fullResponse.statusCode === 500) {
+			return {
+				success: false,
+				statusCode: 500,
+				message: 'Server error while sending test email',
+				body: fullResponse.body,
+			} as unknown as IDataObject;
+		}
+		return fullResponse && fullResponse.body ? fullResponse.body : fullResponse;
+	} catch (err: unknown) {
+		const e = err as unknown as { statusCode?: number; response?: { statusCode?: number } };
+		const status = e?.statusCode ?? e?.response?.statusCode;
+		if (status === 500) {
+			return {
+				success: false,
+				statusCode: 500,
+				message: 'Server error while sending test email',
+			} as unknown as IDataObject;
+		}
+		const msg = err instanceof Error ? err.message : String(err);
+		throw new NodeOperationError(this.getNode(), `Failed to execute ${operation}: ${msg}`);
+	}
 }

--- a/nodes/tanss/sub/OperatingSystems.ts
+++ b/nodes/tanss/sub/OperatingSystems.ts
@@ -8,11 +8,36 @@ export const operatingSystemsOperations: INodeProperties[] = [
 		noDataExpression: true,
 		displayOptions: { show: { resource: ['operatingSystems'] } },
 		options: [
-			{ name: 'Create OS', value: 'createOs', description: 'Creates a new operating system', action: 'Create an OS' },
-			{ name: 'Delete OS', value: 'deleteOs', description: 'Deletes a specific operating system', action: 'Delete an OS' },
-			{ name: 'Get All OS', value: 'getAllOs', description: 'Gets a list of all operating systems', action: 'Get all OS' },
-			{ name: 'Get OS', value: 'getOsById', description: 'Gets a specific operating system', action: 'Get an OS' },
-			{ name: 'Update OS', value: 'updateOs', description: 'Updates an existing operating system', action: 'Update an OS' },
+			{
+				name: 'Create OS',
+				value: 'createOs',
+				description: 'Creates a new operating system',
+				action: 'Create an OS',
+			},
+			{
+				name: 'Delete OS',
+				value: 'deleteOs',
+				description: 'Deletes a specific operating system',
+				action: 'Delete an OS',
+			},
+			{
+				name: 'Get All OS',
+				value: 'getAllOs',
+				description: 'Gets a list of all operating systems',
+				action: 'Get all OS',
+			},
+			{
+				name: 'Get OS',
+				value: 'getOsById',
+				description: 'Gets a specific operating system',
+				action: 'Get an OS',
+			},
+			{
+				name: 'Update OS',
+				value: 'updateOs',
+				description: 'Updates an existing operating system',
+				action: 'Update an OS',
+			},
 		],
 		default: 'getAllOs',
 	},
@@ -35,7 +60,9 @@ export const operatingSystemsFields: INodeProperties[] = [
 		type: 'number' as const,
 		default: 0,
 		description: 'ID of the operating system',
-		displayOptions: { show: { resource: ['operatingSystems'], operation: ['updateOs','getOsById','deleteOs'] } },
+		displayOptions: {
+			show: { resource: ['operatingSystems'], operation: ['updateOs', 'getOsById', 'deleteOs'] },
+		},
 	},
 	{
 		displayName: 'Create OS Fields',
@@ -47,9 +74,19 @@ export const operatingSystemsFields: INodeProperties[] = [
 		options: [
 			{ displayName: 'ID', name: 'id', type: 'number' as const, default: 0 },
 			{ displayName: 'Name', name: 'name', type: 'string' as const, default: '' },
-			{ displayName: 'Server Operating System', name: 'serverOperatingSystem', type: 'boolean' as const, default: false },
+			{
+				displayName: 'Server Operating System',
+				name: 'serverOperatingSystem',
+				type: 'boolean' as const,
+				default: false,
+			},
 			{ displayName: 'Active', name: 'active', type: 'boolean' as const, default: true },
-			{ displayName: 'Article Number', name: 'articleNumber', type: 'string' as const, default: '' },
+			{
+				displayName: 'Article Number',
+				name: 'articleNumber',
+				type: 'string' as const,
+				default: '',
+			},
 		],
 	},
 	{
@@ -62,9 +99,19 @@ export const operatingSystemsFields: INodeProperties[] = [
 		options: [
 			{ displayName: 'ID', name: 'id', type: 'number' as const, default: 0 },
 			{ displayName: 'Name', name: 'name', type: 'string' as const, default: '' },
-			{ displayName: 'Server Operating System', name: 'serverOperatingSystem', type: 'boolean' as const, default: false },
+			{
+				displayName: 'Server Operating System',
+				name: 'serverOperatingSystem',
+				type: 'boolean' as const,
+				default: false,
+			},
 			{ displayName: 'Active', name: 'active', type: 'boolean' as const, default: true },
-			{ displayName: 'Article Number', name: 'articleNumber', type: 'string' as const, default: '' },
+			{
+				displayName: 'Article Number',
+				name: 'articleNumber',
+				type: 'string' as const,
+				default: '',
+			},
 		],
 	},
 ];
@@ -96,8 +143,12 @@ export async function handleOperatingSystems(this: IExecuteFunctions, i: number)
 		case 'createOs': {
 			url = `${credentials.baseURL}/backend/api/v1/os`;
 			requestOptions.method = 'POST';
-			const createOsFields = this.getNodeParameter('createOsFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(createOsFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields provided for OS creation.');
+			const createOsFields = this.getNodeParameter('createOsFields', i, {}) as Record<
+				string,
+				unknown
+			>;
+			if (Object.keys(createOsFields).length === 0)
+				throw new NodeOperationError(this.getNode(), 'No fields provided for OS creation.');
 			requestOptions.body = createOsFields;
 			break;
 		}
@@ -119,20 +170,30 @@ export async function handleOperatingSystems(this: IExecuteFunctions, i: number)
 		case 'updateOs': {
 			url = `${credentials.baseURL}/backend/api/v1/os/${osId}`;
 			requestOptions.method = 'PUT';
-			const updateOsFields = this.getNodeParameter('updateOsFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(updateOsFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields provided for OS update.');
+			const updateOsFields = this.getNodeParameter('updateOsFields', i, {}) as Record<
+				string,
+				unknown
+			>;
+			if (Object.keys(updateOsFields).length === 0)
+				throw new NodeOperationError(this.getNode(), 'No fields provided for OS update.');
 			requestOptions.body = updateOsFields;
 			break;
 		}
 		default:
-			throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized for Operating Systems.`);
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized for Operating Systems.`,
+			);
 	}
 
 	requestOptions.url = url;
 
 	try {
 		type FullResponse = { statusCode: number; body?: unknown };
-		const options = { ...requestOptions, returnFullResponse: true } as unknown as import('n8n-workflow').IHttpRequestOptions;
+		const options = {
+			...requestOptions,
+			returnFullResponse: true,
+		} as unknown as import('n8n-workflow').IHttpRequestOptions;
 		const fullResponse = (await this.helpers.httpRequest(options)) as unknown as FullResponse;
 		if (requestOptions.method === 'DELETE') {
 			return { success: fullResponse.statusCode === 204, statusCode: fullResponse.statusCode };

--- a/nodes/tanss/sub/PCs.ts
+++ b/nodes/tanss/sub/PCs.ts
@@ -12,11 +12,36 @@ export const pcOperations: INodeProperties[] = [
 			},
 		},
 		options: [
-			{ name: 'Create PC', value: 'createPc', description: 'Creates a new PC or server', action: 'Creates a PC' },
-			{ name: 'Delete PC', value: 'deletePc', description: 'Deletes a PC or server', action: 'Deletes a PC' },
-			{ name: 'Get PC by ID', value: 'getPcById', description: 'Fetches a PC or server by a given ID', action: 'Fetches a PC by ID' },
-			{ name: 'List PCs', value: 'listPcs', description: 'Gets a list of PCs or servers', action: 'List pcs' },
-			{ name: 'Update PC', value: 'updatePc', description: 'Updates a PC or server', action: 'Updates a PC' },
+			{
+				name: 'Create PC',
+				value: 'createPc',
+				description: 'Creates a new PC or server',
+				action: 'Creates a PC',
+			},
+			{
+				name: 'Delete PC',
+				value: 'deletePc',
+				description: 'Deletes a PC or server',
+				action: 'Deletes a PC',
+			},
+			{
+				name: 'Get PC by ID',
+				value: 'getPcById',
+				description: 'Fetches a PC or server by a given ID',
+				action: 'Fetches a PC by ID',
+			},
+			{
+				name: 'List PCs',
+				value: 'listPcs',
+				description: 'Gets a list of PCs or servers',
+				action: 'List pcs',
+			},
+			{
+				name: 'Update PC',
+				value: 'updatePc',
+				description: 'Updates a PC or server',
+				action: 'Updates a PC',
+			},
 		],
 		default: 'getPcById',
 	},
@@ -93,29 +118,95 @@ export const pcFields: INodeProperties[] = [
 		options: [
 			{ displayName: 'Active', name: 'active', type: 'boolean' as const, default: false },
 			{ displayName: 'AnyDesk ID', name: 'anydeskId', type: 'string' as const, default: '' },
-			{ displayName: 'AnyDesk Password', name: 'anydeskPassword', type: 'string' as const, default: '', typeOptions: { password: true } },
-			{ displayName: 'Article Number', name: 'articleNumber', type: 'string' as const, default: '' },
-			{ displayName: 'Billing Number', name: 'billingNumber', type: 'string' as const, default: '' },
+			{
+				displayName: 'AnyDesk Password',
+				name: 'anydeskPassword',
+				type: 'string' as const,
+				default: '',
+				typeOptions: { password: true },
+			},
+			{
+				displayName: 'Article Number',
+				name: 'articleNumber',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Billing Number',
+				name: 'billingNumber',
+				type: 'string' as const,
+				default: '',
+			},
 			{ displayName: 'BIOS', name: 'bios', type: 'string' as const, default: '' },
 			{ displayName: 'BIOS Release', name: 'biosRelease', type: 'string' as const, default: '' },
 			{ displayName: 'CPU Frequency', name: 'cpuFrequency', type: 'number' as const, default: 0 },
-			{ displayName: 'CPU Manufacturer ID', name: 'cpuManufacturerId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'CPU Manufacturer ID',
+				name: 'cpuManufacturerId',
+				type: 'number' as const,
+				default: 0,
+			},
 			{ displayName: 'CPU Number', name: 'cpuNumber', type: 'number' as const, default: 0 },
 			{ displayName: 'CPU Type ID', name: 'cpuTypeId', type: 'number' as const, default: 0 },
 			{ displayName: 'Date', name: 'date', type: 'number' as const, default: 0 },
 			{ displayName: 'Description', name: 'description', type: 'string' as const, default: '' },
 			{ displayName: 'Employee ID', name: 'employeeId', type: 'number' as const, default: 0 },
 			{ displayName: 'Host ID', name: 'hostId', type: 'number' as const, default: 0 },
-			{ displayName: 'Internal Remark', name: 'internalRemark', type: 'string' as const, default: '' },
-			{ displayName: 'Inventory Number', name: 'inventoryNumber', type: 'string' as const, default: '' },
-			{ displayName: 'Keyboard Serial Number', name: 'keyboardSerialNumber', type: 'string' as const, default: '' },
+			{
+				displayName: 'Internal Remark',
+				name: 'internalRemark',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Inventory Number',
+				name: 'inventoryNumber',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Keyboard Serial Number',
+				name: 'keyboardSerialNumber',
+				type: 'string' as const,
+				default: '',
+			},
 			{ displayName: 'Location', name: 'location', type: 'string' as const, default: '' },
-			{ displayName: 'Mainboard Manufacturer ID', name: 'mainboardManufacturerId', type: 'number' as const, default: 0 },
-			{ displayName: 'Mainboard Manufacturer Revision', name: 'mainboardManufacturerRevision', type: 'string' as const, default: '' },
-			{ displayName: 'Mainboard Serial Number', name: 'mainboardSerialNumber', type: 'string' as const, default: '' },
-			{ displayName: 'Manufacturer ID', name: 'manufacturerId', type: 'number' as const, default: 0 },
-			{ displayName: 'Manufacturer Number', name: 'manufacturerNumber', type: 'string' as const, default: '' },
-			{ displayName: 'Mouse Serial Number', name: 'mouseSerialNumber', type: 'string' as const, default: '' },
+			{
+				displayName: 'Mainboard Manufacturer ID',
+				name: 'mainboardManufacturerId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Mainboard Manufacturer Revision',
+				name: 'mainboardManufacturerRevision',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Mainboard Serial Number',
+				name: 'mainboardSerialNumber',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Manufacturer ID',
+				name: 'manufacturerId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Manufacturer Number',
+				name: 'manufacturerNumber',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Mouse Serial Number',
+				name: 'mouseSerialNumber',
+				type: 'string' as const,
+				default: '',
+			},
 			{ displayName: 'Name', name: 'name', type: 'string' as const, default: '' },
 			{ displayName: 'OS ID', name: 'osId', type: 'number' as const, default: 0 },
 			{
@@ -133,17 +224,33 @@ export const pcFields: INodeProperties[] = [
 			{ displayName: 'Purchase Price', name: 'purchasePrice', type: 'number' as const, default: 0 },
 			{ displayName: 'Remark', name: 'remark', type: 'string' as const, default: '' },
 			{ displayName: 'Reserved CPU', name: 'reservedCpu', type: 'number' as const, default: 0 },
-			{ displayName: 'Reserved Hard Disk', name: 'reservedHardDisk', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Reserved Hard Disk',
+				name: 'reservedHardDisk',
+				type: 'number' as const,
+				default: 0,
+			},
 			{ displayName: 'Reserved RAM', name: 'reservedRam', type: 'number' as const, default: 0 },
 			{ displayName: 'Selling Price', name: 'sellingPrice', type: 'number' as const, default: 0 },
 			{ displayName: 'Serial Number', name: 'serialNumber', type: 'string' as const, default: '' },
 			{ displayName: 'Server', name: 'server', type: 'boolean' as const, default: false },
-			{ displayName: 'Service Technician ID', name: 'serviceTechnicianId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Service Technician ID',
+				name: 'serviceTechnicianId',
+				type: 'number' as const,
+				default: 0,
+			},
 			{ displayName: 'Show Remark', name: 'showRemark', type: 'boolean' as const, default: false },
 			{ displayName: 'Software', name: 'software', type: 'string' as const, default: '' },
 			{ displayName: 'Storage ID', name: 'storageId', type: 'number' as const, default: 0 },
 			{ displayName: 'TeamViewer ID', name: 'teamviewerId', type: 'string' as const, default: '' },
-			{ displayName: 'TeamViewer Password', name: 'teamviewerPassword', type: 'string' as const, default: '', typeOptions: { password: true } },
+			{
+				displayName: 'TeamViewer Password',
+				name: 'teamviewerPassword',
+				type: 'string' as const,
+				default: '',
+				typeOptions: { password: true },
+			},
 		],
 	},
 	{
@@ -183,7 +290,14 @@ export const pcFields: INodeProperties[] = [
 				default: 'COMPANY_ONLY',
 			},
 			{ displayName: 'Company ID', name: 'companyId', type: 'number' as const, default: 0 },
-			{ displayName: 'OS IDs', name: 'osIds', type: 'multiOptions' as const, typeOptions: { multipleValues: true }, options: [], default: [] },
+			{
+				displayName: 'OS IDs',
+				name: 'osIds',
+				type: 'multiOptions' as const,
+				typeOptions: { multipleValues: true },
+				options: [],
+				default: [],
+			},
 			{
 				displayName: 'Type',
 				name: 'type',
@@ -228,7 +342,10 @@ export async function handlePc(this: IExecuteFunctions, i: number) {
 	switch (operation) {
 		case 'getPcById':
 			if (!pcId || typeof pcId !== 'number' || pcId <= 0)
-				throw new NodeOperationError(this.getNode(), 'Field "PC ID" is required and must be a valid ID.');
+				throw new NodeOperationError(
+					this.getNode(),
+					'Field "PC ID" is required and must be a valid ID.',
+				);
 			url = `${credentials.baseURL}/backend/api/v1/pcs/${pcId}`;
 			requestOptions.method = 'GET';
 			break;
@@ -249,9 +366,15 @@ export async function handlePc(this: IExecuteFunctions, i: number) {
 			if (Object.keys(body).length === 0)
 				throw new NodeOperationError(this.getNode(), 'No data provided for creating the PC.');
 			if (!body.model)
-				throw new NodeOperationError(this.getNode(), 'Field "Model" is required for creating a PC.');
+				throw new NodeOperationError(
+					this.getNode(),
+					'Field "Model" is required for creating a PC.',
+				);
 			if (!body.companyId || typeof body.companyId !== 'number' || body.companyId <= 0)
-				throw new NodeOperationError(this.getNode(), 'Field "Company ID" is required and must be a valid company ID.');
+				throw new NodeOperationError(
+					this.getNode(),
+					'Field "Company ID" is required and must be a valid company ID.',
+				);
 			requestOptions.method = 'POST';
 			requestOptions.body = body;
 			break;
@@ -271,15 +394,23 @@ export async function handlePc(this: IExecuteFunctions, i: number) {
 		}
 
 		default:
-			throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized.`);
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized.`,
+			);
 	}
 
 	requestOptions.url = url;
 
 	try {
-		const responseData = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
+		const responseData = await this.helpers.httpRequest(
+			requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+		);
 
-		if (operation === 'deletePc' && (responseData === undefined || responseData === null || responseData === '')) {
+		if (
+			operation === 'deletePc' &&
+			(responseData === undefined || responseData === null || responseData === '')
+		) {
 			return { success: true, message: 'PC deleted successfully.' };
 		}
 

--- a/nodes/tanss/sub/RemoteSupports.ts
+++ b/nodes/tanss/sub/RemoteSupports.ts
@@ -1,413 +1,564 @@
 import { IExecuteFunctions, INodeProperties, NodeOperationError, IDataObject } from 'n8n-workflow';
 
 export const remoteSupportsOperations: INodeProperties[] = [
-    {
-        displayName: 'Operation',
-        name: 'operation',
-        type: 'options' as const,
-        noDataExpression: true,
-        displayOptions: {
-            show: { resource: ['remoteSupports'] },
-        },
-        options: [
-            { name: 'Create / Import Remote Support', value: 'createRemoteSupport', description: 'Creates/imports a remote support into the TANSS database', action: 'Create remote support' },
-            { name: 'Get List of Remote Supports', value: 'getRemoteSupports', description: 'Gets a list of remote supports based on filter settings', action: 'Get remote supports' },
-            { name: 'Get Remote Support by ID', value: 'getRemoteSupportById', description: 'Gets a remote support from the database by its ID', action: 'Get remote support by id' },
-            { name: 'Update Remote Support', value: 'updateRemoteSupport', description: 'Updates a remote support by ID and sets the new values', action: 'Update remote support' },
-            { name: 'Delete Remote Support', value: 'deleteRemoteSupport', description: 'Deletes a remote support by ID', action: 'Delete remote support' },
-            { name: 'Get Device Assignments', value: 'getDeviceAssignments', description: 'Gets all device assignments for the remote support type', action: 'Get device assignments' },
-            { name: 'Create Device Assignment', value: 'createAssignDevice', description: 'Creates a device assignment mapping deviceId -> company/link', action: 'Create device assignment' },
-            { name: 'Delete Device Assignment', value: 'deleteAssignDevice', description: 'Deletes a device assignment by deviceId', action: 'Delete device assignment' },
-            { name: 'Get Technician Assignments', value: 'getEmployeeAssignments', description: 'Gets all employee (technician) assignments for the remote support type', action: 'Get technician assignments' },
-            { name: 'Create Technician Assignment', value: 'createAssignEmployee', description: 'Creates an assignment mapping userId -> employeeId', action: 'Create technician assignment' },
-            { name: 'Delete Technician Assignment', value: 'deleteAssignEmployee', description: 'Deletes a technician assignment by userId', action: 'Delete technician assignment' },
-        ],
-        default: 'createRemoteSupport',
-    },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options' as const,
+		noDataExpression: true,
+		displayOptions: {
+			show: { resource: ['remoteSupports'] },
+		},
+		options: [
+			{
+				name: 'Create / Import Remote Support',
+				value: 'createRemoteSupport',
+				description: 'Creates/imports a remote support into the TANSS database',
+				action: 'Create remote support',
+			},
+			{
+				name: 'Get List of Remote Supports',
+				value: 'getRemoteSupports',
+				description: 'Gets a list of remote supports based on filter settings',
+				action: 'Get remote supports',
+			},
+			{
+				name: 'Get Remote Support by ID',
+				value: 'getRemoteSupportById',
+				description: 'Gets a remote support from the database by its ID',
+				action: 'Get remote support by id',
+			},
+			{
+				name: 'Update Remote Support',
+				value: 'updateRemoteSupport',
+				description: 'Updates a remote support by ID and sets the new values',
+				action: 'Update remote support',
+			},
+			{
+				name: 'Delete Remote Support',
+				value: 'deleteRemoteSupport',
+				description: 'Deletes a remote support by ID',
+				action: 'Delete remote support',
+			},
+			{
+				name: 'Get Device Assignments',
+				value: 'getDeviceAssignments',
+				description: 'Gets all device assignments for the remote support type',
+				action: 'Get device assignments',
+			},
+			{
+				name: 'Create Device Assignment',
+				value: 'createAssignDevice',
+				description: 'Creates a device assignment mapping deviceId -> company/link',
+				action: 'Create device assignment',
+			},
+			{
+				name: 'Delete Device Assignment',
+				value: 'deleteAssignDevice',
+				description: 'Deletes a device assignment by deviceId',
+				action: 'Delete device assignment',
+			},
+			{
+				name: 'Get Technician Assignments',
+				value: 'getEmployeeAssignments',
+				description: 'Gets all employee (technician) assignments for the remote support type',
+				action: 'Get technician assignments',
+			},
+			{
+				name: 'Create Technician Assignment',
+				value: 'createAssignEmployee',
+				description: 'Creates an assignment mapping userId -> employeeId',
+				action: 'Create technician assignment',
+			},
+			{
+				name: 'Delete Technician Assignment',
+				value: 'deleteAssignEmployee',
+				description: 'Deletes a technician assignment by userId',
+				action: 'Delete technician assignment',
+			},
+		],
+		default: 'createRemoteSupport',
+	},
 ];
 
 export const remoteSupportsFields: INodeProperties[] = [
-    {
-        displayName: 'API Token',
-        name: 'apiToken',
-        type: 'string' as const,
-        required: true,
-        typeOptions: { password: true },
-        default: '',
-        description: 'API token obtained from the TANSS web interface (must be generated in TANSS)',
-        displayOptions: { show: { resource: ['remoteSupports'] } },
-    },
-    {
-        displayName: 'Assign Device Object',
-        name: 'assignDeviceObject',
-        type: 'collection' as const,
-        placeholder: 'Add Field',
-        displayOptions: { show: { resource: ['remoteSupports'], operation: ['createAssignDevice', 'deleteAssignDevice'] } },
-        default: {},
-        options: [
-            { displayName: 'deviceId', name: 'deviceId', type: 'string' as const, default: '' },
-            { displayName: 'companyId', name: 'companyId', type: 'number' as const, default: 0 },
-            { displayName: 'linkTypeId', name: 'linkTypeId', type: 'number' as const, default: 0 },
-            { displayName: 'linkId', name: 'linkId', type: 'number' as const, default: 0 },
-        ],
-    },
+	{
+		displayName: 'API Token',
+		name: 'apiToken',
+		type: 'string' as const,
+		required: true,
+		typeOptions: { password: true },
+		default: '',
+		description: 'API token obtained from the TANSS web interface (must be generated in TANSS)',
+		displayOptions: { show: { resource: ['remoteSupports'] } },
+	},
+	{
+		displayName: 'Assign Device Object',
+		name: 'assignDeviceObject',
+		type: 'collection' as const,
+		placeholder: 'Add Field',
+		displayOptions: {
+			show: {
+				resource: ['remoteSupports'],
+				operation: ['createAssignDevice', 'deleteAssignDevice'],
+			},
+		},
+		default: {},
+		options: [
+			{ displayName: 'deviceId', name: 'deviceId', type: 'string' as const, default: '' },
+			{ displayName: 'companyId', name: 'companyId', type: 'number' as const, default: 0 },
+			{ displayName: 'linkTypeId', name: 'linkTypeId', type: 'number' as const, default: 0 },
+			{ displayName: 'linkId', name: 'linkId', type: 'number' as const, default: 0 },
+		],
+	},
 
-    {
-        displayName: 'Assign Employee Object',
-        name: 'assignEmployeeObject',
-        type: 'collection' as const,
-        placeholder: 'Add Field',
-        displayOptions: { show: { resource: ['remoteSupports'], operation: ['createAssignEmployee', 'deleteAssignEmployee'] } },
-        default: {},
-        options: [
-            { displayName: 'userId', name: 'userId', type: 'string' as const, default: '' },
-            { displayName: 'employeeId', name: 'employeeId', type: 'number' as const, default: 0 },
-        ],
-    },
+	{
+		displayName: 'Assign Employee Object',
+		name: 'assignEmployeeObject',
+		type: 'collection' as const,
+		placeholder: 'Add Field',
+		displayOptions: {
+			show: {
+				resource: ['remoteSupports'],
+				operation: ['createAssignEmployee', 'deleteAssignEmployee'],
+			},
+		},
+		default: {},
+		options: [
+			{ displayName: 'userId', name: 'userId', type: 'string' as const, default: '' },
+			{ displayName: 'employeeId', name: 'employeeId', type: 'number' as const, default: 0 },
+		],
+	},
 
-    {
-        displayName: 'Filter Settings',
-        name: 'getRemoteSupportsFilters',
-        type: 'collection' as const,
-        placeholder: 'Add Filter',
-        displayOptions: { show: { resource: ['remoteSupports'], operation: ['getRemoteSupports'] } },
-        default: {},
-        options: [
-            { displayName: 'Timeframe From (Timestamp)', name: 'timeFrom', type: 'number' as const, default: 0 },
-            { displayName: 'Timeframe To (Timestamp)', name: 'timeTo', type: 'number' as const, default: 0 },
-            { displayName: 'Employee ID', name: 'employeeId', type: 'number' as const, default: 0 },
-            { displayName: 'Company ID', name: 'companyId', type: 'number' as const, default: 0 },
-            { displayName: 'Type ID', name: 'typeId', type: 'number' as const, default: 0 },
-            { displayName: 'Text', name: 'text', type: 'string' as const, default: '' },
-        ],
-    },
+	{
+		displayName: 'Filter Settings',
+		name: 'getRemoteSupportsFilters',
+		type: 'collection' as const,
+		placeholder: 'Add Filter',
+		displayOptions: { show: { resource: ['remoteSupports'], operation: ['getRemoteSupports'] } },
+		default: {},
+		options: [
+			{
+				displayName: 'Timeframe From (Timestamp)',
+				name: 'timeFrom',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Timeframe To (Timestamp)',
+				name: 'timeTo',
+				type: 'number' as const,
+				default: 0,
+			},
+			{ displayName: 'Employee ID', name: 'employeeId', type: 'number' as const, default: 0 },
+			{ displayName: 'Company ID', name: 'companyId', type: 'number' as const, default: 0 },
+			{ displayName: 'Type ID', name: 'typeId', type: 'number' as const, default: 0 },
+			{ displayName: 'Text', name: 'text', type: 'string' as const, default: '' },
+		],
+	},
 
-    {
-        displayName: 'Remote Object',
-        name: 'remoteObject',
-        type: 'collection' as const,
-        placeholder: 'Add Field',
-    displayOptions: { show: { resource: ['remoteSupports'], operation: ['createRemoteSupport', 'updateRemoteSupport'] } },
-        default: {},
-        options: [
-            { displayName: 'remoteMaintenanceId', name: 'remoteMaintenanceId', type: 'string' as const, default: '' },
-            { displayName: 'userId', name: 'userId', type: 'string' as const, default: '' },
-            { displayName: 'userName', name: 'userName', type: 'string' as const, default: '' },
-            { displayName: 'employeeId', name: 'employeeId', type: 'number' as const, default: 0 },
-            { displayName: 'deviceId', name: 'deviceId', type: 'string' as const, default: '' },
-            { displayName: 'deviceName', name: 'deviceName', type: 'string' as const, default: '' },
-            { displayName: 'companyId', name: 'companyId', type: 'number' as const, default: 0 },
-            { displayName: 'linkTypeId', name: 'linkTypeId', type: 'number' as const, default: 0 },
-            { displayName: 'linkId', name: 'linkId', type: 'number' as const, default: 0 },
-            { displayName: 'startTime (Timestamp)', name: 'startTime', type: 'number' as const, default: 0 },
-            { displayName: 'endTime (Timestamp)', name: 'endTime', type: 'number' as const, default: 0 },
-            { displayName: 'Comment', name: 'comment', type: 'string' as const, default: '' },
-        ],
-    },
-    {
-        displayName: 'Remote Support ID',
-        name: 'remoteSupportId',
-        type: 'number' as const,
-        default: 0,
-        description: 'ID of the remote support to fetch / update / delete',
-        displayOptions: {
-            show: {
-                resource: ['remoteSupports'],
-                operation: ['getRemoteSupportById', 'updateRemoteSupport', 'deleteRemoteSupport'],
-            },
-        },
-    },
+	{
+		displayName: 'Remote Object',
+		name: 'remoteObject',
+		type: 'collection' as const,
+		placeholder: 'Add Field',
+		displayOptions: {
+			show: {
+				resource: ['remoteSupports'],
+				operation: ['createRemoteSupport', 'updateRemoteSupport'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'remoteMaintenanceId',
+				name: 'remoteMaintenanceId',
+				type: 'string' as const,
+				default: '',
+			},
+			{ displayName: 'userId', name: 'userId', type: 'string' as const, default: '' },
+			{ displayName: 'userName', name: 'userName', type: 'string' as const, default: '' },
+			{ displayName: 'employeeId', name: 'employeeId', type: 'number' as const, default: 0 },
+			{ displayName: 'deviceId', name: 'deviceId', type: 'string' as const, default: '' },
+			{ displayName: 'deviceName', name: 'deviceName', type: 'string' as const, default: '' },
+			{ displayName: 'companyId', name: 'companyId', type: 'number' as const, default: 0 },
+			{ displayName: 'linkTypeId', name: 'linkTypeId', type: 'number' as const, default: 0 },
+			{ displayName: 'linkId', name: 'linkId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'startTime (Timestamp)',
+				name: 'startTime',
+				type: 'number' as const,
+				default: 0,
+			},
+			{ displayName: 'endTime (Timestamp)', name: 'endTime', type: 'number' as const, default: 0 },
+			{ displayName: 'Comment', name: 'comment', type: 'string' as const, default: '' },
+		],
+	},
+	{
+		displayName: 'Remote Support ID',
+		name: 'remoteSupportId',
+		type: 'number' as const,
+		default: 0,
+		description: 'ID of the remote support to fetch / update / delete',
+		displayOptions: {
+			show: {
+				resource: ['remoteSupports'],
+				operation: ['getRemoteSupportById', 'updateRemoteSupport', 'deleteRemoteSupport'],
+			},
+		},
+	},
 ];
 
 export async function handleRemoteSupports(this: IExecuteFunctions, i: number) {
-    const operation = this.getNodeParameter('operation', i) as string;
-    const credentials = await this.getCredentials('tanssApi');
-    if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
+	const operation = this.getNodeParameter('operation', i) as string;
+	const credentials = await this.getCredentials('tanssApi');
+	if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
 
-    const apiToken = this.getNodeParameter('apiToken', i, '') as string;
-    const base = credentials.baseURL as string;
-    if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
+	const apiToken = this.getNodeParameter('apiToken', i, '') as string;
+	const base = credentials.baseURL as string;
+	if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
 
-    let url = '';
-    const requestOptions: {
-        method: 'GET' | 'PUT' | 'POST' | 'DELETE';
-        headers: { [key: string]: string };
-        json: boolean;
-        body?: IDataObject;
-        url: string;
-    } = {
-        method: 'POST',
-        headers: { Accept: 'application/json' },
-        json: true,
-        url,
-    };
+	let url = '';
+	const requestOptions: {
+		method: 'GET' | 'PUT' | 'POST' | 'DELETE';
+		headers: { [key: string]: string };
+		json: boolean;
+		body?: IDataObject;
+		url: string;
+	} = {
+		method: 'POST',
+		headers: { Accept: 'application/json' },
+		json: true,
+		url,
+	};
 
-    if (apiToken && apiToken.toString().trim() !== '') {
-        const tokenValue = String(apiToken).startsWith('Bearer ') ? String(apiToken) : `Bearer ${String(apiToken)}`;
-        requestOptions.headers.Authorization = tokenValue;
-        requestOptions.headers.apiToken = tokenValue;
-    }
+	if (apiToken && apiToken.toString().trim() !== '') {
+		const tokenValue = String(apiToken).startsWith('Bearer ')
+			? String(apiToken)
+			: `Bearer ${String(apiToken)}`;
+		requestOptions.headers.Authorization = tokenValue;
+		requestOptions.headers.apiToken = tokenValue;
+	}
 
-    switch (operation) {
-        case 'createRemoteSupport': {
-            const body: IDataObject = {};
-            const fields = this.getNodeParameter('remoteObject', i, {}) as IDataObject;
+	switch (operation) {
+		case 'createRemoteSupport': {
+			const body: IDataObject = {};
+			const fields = this.getNodeParameter('remoteObject', i, {}) as IDataObject;
 
-            if (fields.remoteMaintenanceId && String(fields.remoteMaintenanceId).trim() !== '')
-                body.remoteMaintenanceId = String(fields.remoteMaintenanceId).trim();
+			if (fields.remoteMaintenanceId && String(fields.remoteMaintenanceId).trim() !== '')
+				body.remoteMaintenanceId = String(fields.remoteMaintenanceId).trim();
 
-            if (fields.userId && String(fields.userId).trim() !== '') body.userId = String(fields.userId).trim();
+			if (fields.userId && String(fields.userId).trim() !== '')
+				body.userId = String(fields.userId).trim();
 
-            if (fields.userName && String(fields.userName).trim() !== '') body.userName = String(fields.userName).trim();
+			if (fields.userName && String(fields.userName).trim() !== '')
+				body.userName = String(fields.userName).trim();
 
-            const employeeId = Number(fields.employeeId) || 0;
-            if (employeeId > 0) body.employeeId = employeeId;
+			const employeeId = Number(fields.employeeId) || 0;
+			if (employeeId > 0) body.employeeId = employeeId;
 
-            if (fields.deviceId && String(fields.deviceId).trim() !== '') body.deviceId = String(fields.deviceId).trim();
+			if (fields.deviceId && String(fields.deviceId).trim() !== '')
+				body.deviceId = String(fields.deviceId).trim();
 
-            if (fields.deviceName && String(fields.deviceName).trim() !== '') body.deviceName = String(fields.deviceName).trim();
+			if (fields.deviceName && String(fields.deviceName).trim() !== '')
+				body.deviceName = String(fields.deviceName).trim();
 
-            const companyId = Number(fields.companyId) || 0;
-            if (companyId > 0) body.companyId = companyId;
+			const companyId = Number(fields.companyId) || 0;
+			if (companyId > 0) body.companyId = companyId;
 
-            const linkTypeId = Number(fields.linkTypeId) || 0;
-            if (linkTypeId > 0) body.linkTypeId = linkTypeId;
+			const linkTypeId = Number(fields.linkTypeId) || 0;
+			if (linkTypeId > 0) body.linkTypeId = linkTypeId;
 
-            const linkId = Number(fields.linkId) || 0;
-            if (linkId > 0) body.linkId = linkId;
+			const linkId = Number(fields.linkId) || 0;
+			if (linkId > 0) body.linkId = linkId;
 
-            const startTime = Number(fields.startTime) || 0;
-            if (startTime > 0) body.startTime = startTime;
+			const startTime = Number(fields.startTime) || 0;
+			if (startTime > 0) body.startTime = startTime;
 
-            const endTime = Number(fields.endTime) || 0;
-            if (endTime > 0) body.endTime = endTime;
+			const endTime = Number(fields.endTime) || 0;
+			if (endTime > 0) body.endTime = endTime;
 
-            if (fields.comment && String(fields.comment).trim() !== '') body.comment = String(fields.comment).trim();
+			if (fields.comment && String(fields.comment).trim() !== '')
+				body.comment = String(fields.comment).trim();
 
-            url = `${credentials.baseURL}/backend/api/remoteSupports/v1`;
-            requestOptions.method = 'POST';
-            requestOptions.url = url;
-            requestOptions.headers['Content-Type'] = 'application/json';
-            requestOptions.body = body;
-            break;
-        }
+			url = `${credentials.baseURL}/backend/api/remoteSupports/v1`;
+			requestOptions.method = 'POST';
+			requestOptions.url = url;
+			requestOptions.headers['Content-Type'] = 'application/json';
+			requestOptions.body = body;
+			break;
+		}
 
-        case 'getRemoteSupports': {
-            const filters = this.getNodeParameter('getRemoteSupportsFilters', i, {}) as IDataObject;
-            const timeframeFrom = Number(filters.timeFrom) || 0;
-            const timeframeTo = Number(filters.timeTo) || 0;
-            const body: IDataObject = {};
-            if (timeframeFrom > 0 || timeframeTo > 0) {
-                const timeframeObj: IDataObject = {};
-                if (timeframeFrom > 0) timeframeObj.from = timeframeFrom;
-                if (timeframeTo > 0) timeframeObj.to = timeframeTo;
-                body.timeframe = timeframeObj;
-            }
+		case 'getRemoteSupports': {
+			const filters = this.getNodeParameter('getRemoteSupportsFilters', i, {}) as IDataObject;
+			const timeframeFrom = Number(filters.timeFrom) || 0;
+			const timeframeTo = Number(filters.timeTo) || 0;
+			const body: IDataObject = {};
+			if (timeframeFrom > 0 || timeframeTo > 0) {
+				const timeframeObj: IDataObject = {};
+				if (timeframeFrom > 0) timeframeObj.from = timeframeFrom;
+				if (timeframeTo > 0) timeframeObj.to = timeframeTo;
+				body.timeframe = timeframeObj;
+			}
 
-            const employeeId = Number(filters.employeeId) || 0;
-            if (employeeId > 0) body.employeeId = employeeId;
+			const employeeId = Number(filters.employeeId) || 0;
+			if (employeeId > 0) body.employeeId = employeeId;
 
-            const companyId = Number(filters.companyId) || 0;
-            if (companyId > 0) body.companyId = companyId;
+			const companyId = Number(filters.companyId) || 0;
+			if (companyId > 0) body.companyId = companyId;
 
-            const typeId = Number(filters.typeId) || 0;
-            if (typeId > 0) body.typeId = typeId;
+			const typeId = Number(filters.typeId) || 0;
+			if (typeId > 0) body.typeId = typeId;
 
-            if (filters.text && String(filters.text).trim() !== '') body.text = String(filters.text).trim();
+			if (filters.text && String(filters.text).trim() !== '')
+				body.text = String(filters.text).trim();
 
-            url = `${credentials.baseURL}/backend/api/remoteSupports/v1`;
-            requestOptions.method = 'PUT';
-            requestOptions.url = url;
-            requestOptions.headers['Content-Type'] = 'application/json';
-            requestOptions.body = body;
-            break;
-        }
+			url = `${credentials.baseURL}/backend/api/remoteSupports/v1`;
+			requestOptions.method = 'PUT';
+			requestOptions.url = url;
+			requestOptions.headers['Content-Type'] = 'application/json';
+			requestOptions.body = body;
+			break;
+		}
 
-        case 'getDeviceAssignments': {
-            url = `${credentials.baseURL}/backend/api/remoteSupports/v1/assignDevice`;
-            requestOptions.method = 'GET';
-            requestOptions.url = url;
-            delete requestOptions.headers['Content-Type'];
-            break;
-        }
+		case 'getDeviceAssignments': {
+			url = `${credentials.baseURL}/backend/api/remoteSupports/v1/assignDevice`;
+			requestOptions.method = 'GET';
+			requestOptions.url = url;
+			delete requestOptions.headers['Content-Type'];
+			break;
+		}
 
-        case 'createAssignDevice': {
-            const assignJson = this.getNodeParameter('assignDeviceJson', i, '') as string;
-            let body: IDataObject = {};
-            if (assignJson && assignJson.trim() !== '') {
-                try {
-                    const parsed = JSON.parse(assignJson);
-                    if (typeof parsed !== 'object' || parsed === null) throw new Error('assignDeviceJson must be a JSON object.');
-                    body = parsed as IDataObject;
-                } catch (err) {
-                    const msg = err instanceof Error ? err.message : String(err);
-                    throw new NodeOperationError(this.getNode(), `assignDeviceJson must be valid JSON: ${msg}`);
-                }
-            } else {
-                const fields = this.getNodeParameter('assignDeviceObject', i, {}) as IDataObject;
-                if (fields.deviceId && String(fields.deviceId).trim() !== '') body.deviceId = String(fields.deviceId).trim();
-                const companyId = Number(fields.companyId) || 0;
-                if (companyId > 0) body.companyId = companyId;
-                const linkTypeId = Number(fields.linkTypeId) || 0;
-                if (linkTypeId > 0) body.linkTypeId = linkTypeId;
-                const linkId = Number(fields.linkId) || 0;
-                if (linkId > 0) body.linkId = linkId;
-            }
+		case 'createAssignDevice': {
+			const assignJson = this.getNodeParameter('assignDeviceJson', i, '') as string;
+			let body: IDataObject = {};
+			if (assignJson && assignJson.trim() !== '') {
+				try {
+					const parsed = JSON.parse(assignJson);
+					if (typeof parsed !== 'object' || parsed === null)
+						throw new Error('assignDeviceJson must be a JSON object.');
+					body = parsed as IDataObject;
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					throw new NodeOperationError(
+						this.getNode(),
+						`assignDeviceJson must be valid JSON: ${msg}`,
+					);
+				}
+			} else {
+				const fields = this.getNodeParameter('assignDeviceObject', i, {}) as IDataObject;
+				if (fields.deviceId && String(fields.deviceId).trim() !== '')
+					body.deviceId = String(fields.deviceId).trim();
+				const companyId = Number(fields.companyId) || 0;
+				if (companyId > 0) body.companyId = companyId;
+				const linkTypeId = Number(fields.linkTypeId) || 0;
+				if (linkTypeId > 0) body.linkTypeId = linkTypeId;
+				const linkId = Number(fields.linkId) || 0;
+				if (linkId > 0) body.linkId = linkId;
+			}
 
-            url = `${credentials.baseURL}/backend/api/remoteSupports/v1/assignDevice`;
-            requestOptions.method = 'POST';
-            requestOptions.url = url;
-            requestOptions.headers['Content-Type'] = 'application/json';
-            requestOptions.body = body;
-            break;
-        }
+			url = `${credentials.baseURL}/backend/api/remoteSupports/v1/assignDevice`;
+			requestOptions.method = 'POST';
+			requestOptions.url = url;
+			requestOptions.headers['Content-Type'] = 'application/json';
+			requestOptions.body = body;
+			break;
+		}
 
-        case 'deleteAssignDevice': {
-            const assignJson = this.getNodeParameter('assignDeviceJson', i, '') as string;
-            let body: IDataObject = {};
-            if (assignJson && assignJson.trim() !== '') {
-                try {
-                    const parsed = JSON.parse(assignJson);
-                    if (typeof parsed !== 'object' || parsed === null) throw new Error('assignDeviceJson must be a JSON object.');
-                    body = parsed as IDataObject;
-                } catch (err) {
-                    const msg = err instanceof Error ? err.message : String(err);
-                    throw new NodeOperationError(this.getNode(), `assignDeviceJson must be valid JSON: ${msg}`);
-                }
-            } else {
-                const fields = this.getNodeParameter('assignDeviceObject', i, {}) as IDataObject;
-                if (fields.deviceId && String(fields.deviceId).trim() !== '') body.deviceId = String(fields.deviceId).trim();
-            }
+		case 'deleteAssignDevice': {
+			const assignJson = this.getNodeParameter('assignDeviceJson', i, '') as string;
+			let body: IDataObject = {};
+			if (assignJson && assignJson.trim() !== '') {
+				try {
+					const parsed = JSON.parse(assignJson);
+					if (typeof parsed !== 'object' || parsed === null)
+						throw new Error('assignDeviceJson must be a JSON object.');
+					body = parsed as IDataObject;
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					throw new NodeOperationError(
+						this.getNode(),
+						`assignDeviceJson must be valid JSON: ${msg}`,
+					);
+				}
+			} else {
+				const fields = this.getNodeParameter('assignDeviceObject', i, {}) as IDataObject;
+				if (fields.deviceId && String(fields.deviceId).trim() !== '')
+					body.deviceId = String(fields.deviceId).trim();
+			}
 
-            url = `${credentials.baseURL}/backend/api/remoteSupports/v1/assignDevice`;
-            requestOptions.method = 'DELETE';
-            requestOptions.url = url;
-            requestOptions.headers['Content-Type'] = 'application/json';
-            requestOptions.body = body;
+			url = `${credentials.baseURL}/backend/api/remoteSupports/v1/assignDevice`;
+			requestOptions.method = 'DELETE';
+			requestOptions.url = url;
+			requestOptions.headers['Content-Type'] = 'application/json';
+			requestOptions.body = body;
 
-            try {
-                const fullResponse = await this.helpers.httpRequest({ ...(requestOptions as unknown as IDataObject), simple: false, resolveWithFullResponse: true } as unknown as import('n8n-workflow').IHttpRequestOptions);
-                if (fullResponse && fullResponse.statusCode === 204) {
-                    return { success: true, statusCode: 204, message: 'Device assignment deleted' } as unknown as IDataObject;
-                }
-                return fullResponse && fullResponse.body ? fullResponse.body : fullResponse;
-            } catch (err: unknown) {
-                const e = err as unknown as { statusCode?: number; response?: { statusCode?: number } };
-                const status = e?.statusCode ?? e?.response?.statusCode;
-                if (status === 403) {
-                    return { success: false, statusCode: 403, message: 'forbidden' } as unknown as IDataObject;
-                }
-                const msg = err instanceof Error ? err.message : String(err);
-                throw new NodeOperationError(this.getNode(), `Failed to execute deleteAssignDevice: ${msg}`);
-            }
-        }
+			try {
+				const fullResponse = await this.helpers.httpRequest({
+					...(requestOptions as unknown as IDataObject),
+					simple: false,
+					resolveWithFullResponse: true,
+				} as unknown as import('n8n-workflow').IHttpRequestOptions);
+				if (fullResponse && fullResponse.statusCode === 204) {
+					return {
+						success: true,
+						statusCode: 204,
+						message: 'Device assignment deleted',
+					} as unknown as IDataObject;
+				}
+				return fullResponse && fullResponse.body ? fullResponse.body : fullResponse;
+			} catch (err: unknown) {
+				const e = err as unknown as { statusCode?: number; response?: { statusCode?: number } };
+				const status = e?.statusCode ?? e?.response?.statusCode;
+				if (status === 403) {
+					return {
+						success: false,
+						statusCode: 403,
+						message: 'forbidden',
+					} as unknown as IDataObject;
+				}
+				const msg = err instanceof Error ? err.message : String(err);
+				throw new NodeOperationError(
+					this.getNode(),
+					`Failed to execute deleteAssignDevice: ${msg}`,
+				);
+			}
+		}
 
-        case 'getRemoteSupportById': {
-            const remoteSupportId = Number(this.getNodeParameter('remoteSupportId', i, 0)) || 0;
-            if (remoteSupportId <= 0) throw new NodeOperationError(this.getNode(), 'remoteSupportId must be set and > 0');
+		case 'getRemoteSupportById': {
+			const remoteSupportId = Number(this.getNodeParameter('remoteSupportId', i, 0)) || 0;
+			if (remoteSupportId <= 0)
+				throw new NodeOperationError(this.getNode(), 'remoteSupportId must be set and > 0');
 
-            url = `${credentials.baseURL}/backend/api/remoteSupports/v1/${remoteSupportId}`;
-            requestOptions.method = 'GET';
-            requestOptions.url = url;
-            delete requestOptions.headers['Content-Type'];
-            break;
-        }
+			url = `${credentials.baseURL}/backend/api/remoteSupports/v1/${remoteSupportId}`;
+			requestOptions.method = 'GET';
+			requestOptions.url = url;
+			delete requestOptions.headers['Content-Type'];
+			break;
+		}
 
-        case 'updateRemoteSupport': {
-            const remoteSupportId = Number(this.getNodeParameter('remoteSupportId', i, 0)) || 0;
-            if (remoteSupportId <= 0) throw new NodeOperationError(this.getNode(), 'remoteSupportId must be set and > 0');
+		case 'updateRemoteSupport': {
+			const remoteSupportId = Number(this.getNodeParameter('remoteSupportId', i, 0)) || 0;
+			if (remoteSupportId <= 0)
+				throw new NodeOperationError(this.getNode(), 'remoteSupportId must be set and > 0');
 
-            const remoteJson = this.getNodeParameter('remoteJson', i, '') as string;
-            let body: IDataObject = {};
+			const remoteJson = this.getNodeParameter('remoteJson', i, '') as string;
+			let body: IDataObject = {};
 
-            if (remoteJson && remoteJson.trim() !== '') {
-                try {
-                    const parsed = JSON.parse(remoteJson);
-                    if (typeof parsed !== 'object' || parsed === null) {
-                        throw new Error('remoteJson must be a JSON object.');
-                    }
-                    body = parsed as IDataObject;
-                } catch (err) {
-                    const msg = err instanceof Error ? err.message : String(err);
-                    throw new NodeOperationError(this.getNode(), `remoteJson must be valid JSON: ${msg}`);
-                }
-            } else {
-                const fields = this.getNodeParameter('remoteObject', i, {}) as IDataObject;
+			if (remoteJson && remoteJson.trim() !== '') {
+				try {
+					const parsed = JSON.parse(remoteJson);
+					if (typeof parsed !== 'object' || parsed === null) {
+						throw new Error('remoteJson must be a JSON object.');
+					}
+					body = parsed as IDataObject;
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					throw new NodeOperationError(this.getNode(), `remoteJson must be valid JSON: ${msg}`);
+				}
+			} else {
+				const fields = this.getNodeParameter('remoteObject', i, {}) as IDataObject;
 
-                if (fields.remoteMaintenanceId && String(fields.remoteMaintenanceId).trim() !== '')
-                    body.remoteMaintenanceId = String(fields.remoteMaintenanceId).trim();
+				if (fields.remoteMaintenanceId && String(fields.remoteMaintenanceId).trim() !== '')
+					body.remoteMaintenanceId = String(fields.remoteMaintenanceId).trim();
 
-                if (fields.userId && String(fields.userId).trim() !== '') body.userId = String(fields.userId).trim();
+				if (fields.userId && String(fields.userId).trim() !== '')
+					body.userId = String(fields.userId).trim();
 
-                if (fields.userName && String(fields.userName).trim() !== '') body.userName = String(fields.userName).trim();
+				if (fields.userName && String(fields.userName).trim() !== '')
+					body.userName = String(fields.userName).trim();
 
-                const employeeId = Number(fields.employeeId) || 0;
-                if (employeeId > 0) body.employeeId = employeeId;
+				const employeeId = Number(fields.employeeId) || 0;
+				if (employeeId > 0) body.employeeId = employeeId;
 
-                if (fields.deviceId && String(fields.deviceId).trim() !== '') body.deviceId = String(fields.deviceId).trim();
+				if (fields.deviceId && String(fields.deviceId).trim() !== '')
+					body.deviceId = String(fields.deviceId).trim();
 
-                if (fields.deviceName && String(fields.deviceName).trim() !== '') body.deviceName = String(fields.deviceName).trim();
+				if (fields.deviceName && String(fields.deviceName).trim() !== '')
+					body.deviceName = String(fields.deviceName).trim();
 
-                const companyId = Number(fields.companyId) || 0;
-                if (companyId > 0) body.companyId = companyId;
+				const companyId = Number(fields.companyId) || 0;
+				if (companyId > 0) body.companyId = companyId;
 
-                const linkTypeId = Number(fields.linkTypeId) || 0;
-                if (linkTypeId > 0) body.linkTypeId = linkTypeId;
+				const linkTypeId = Number(fields.linkTypeId) || 0;
+				if (linkTypeId > 0) body.linkTypeId = linkTypeId;
 
-                const linkId = Number(fields.linkId) || 0;
-                if (linkId > 0) body.linkId = linkId;
+				const linkId = Number(fields.linkId) || 0;
+				if (linkId > 0) body.linkId = linkId;
 
-                const startTime = Number(fields.startTime) || 0;
-                if (startTime > 0) body.startTime = startTime;
+				const startTime = Number(fields.startTime) || 0;
+				if (startTime > 0) body.startTime = startTime;
 
-                const endTime = Number(fields.endTime) || 0;
-                if (endTime > 0) body.endTime = endTime;
+				const endTime = Number(fields.endTime) || 0;
+				if (endTime > 0) body.endTime = endTime;
 
-                if (fields.comment && String(fields.comment).trim() !== '') body.comment = String(fields.comment).trim();
-            }
+				if (fields.comment && String(fields.comment).trim() !== '')
+					body.comment = String(fields.comment).trim();
+			}
 
-            url = `${credentials.baseURL}/backend/api/remoteSupports/v1/${remoteSupportId}`;
-            requestOptions.method = 'PUT';
-            requestOptions.url = url;
-            requestOptions.headers['Content-Type'] = 'application/json';
-            requestOptions.body = body;
-            break;
-        }
+			url = `${credentials.baseURL}/backend/api/remoteSupports/v1/${remoteSupportId}`;
+			requestOptions.method = 'PUT';
+			requestOptions.url = url;
+			requestOptions.headers['Content-Type'] = 'application/json';
+			requestOptions.body = body;
+			break;
+		}
 
-        case 'deleteRemoteSupport': {
-            const remoteSupportId = Number(this.getNodeParameter('remoteSupportId', i, 0)) || 0;
-            if (remoteSupportId <= 0) throw new NodeOperationError(this.getNode(), 'remoteSupportId must be set and > 0');
+		case 'deleteRemoteSupport': {
+			const remoteSupportId = Number(this.getNodeParameter('remoteSupportId', i, 0)) || 0;
+			if (remoteSupportId <= 0)
+				throw new NodeOperationError(this.getNode(), 'remoteSupportId must be set and > 0');
 
-            url = `${credentials.baseURL}/backend/api/remoteSupports/v1/${remoteSupportId}`;
-            requestOptions.method = 'DELETE';
-            requestOptions.url = url;
+			url = `${credentials.baseURL}/backend/api/remoteSupports/v1/${remoteSupportId}`;
+			requestOptions.method = 'DELETE';
+			requestOptions.url = url;
 
-            try {
-                const fullResponse = await this.helpers.httpRequest({ ...(requestOptions as unknown as IDataObject), simple: false, resolveWithFullResponse: true } as unknown as import('n8n-workflow').IHttpRequestOptions);
-                if (fullResponse && fullResponse.statusCode === 204) {
-                    return { success: true, statusCode: 204, message: 'Remote support deleted' } as unknown as IDataObject;
-                }
-                return fullResponse && fullResponse.body ? fullResponse.body : fullResponse;
-            } catch (err: unknown) {
-                const e = err as unknown as { statusCode?: number; response?: { statusCode?: number } };
-                const status = e?.statusCode ?? e?.response?.statusCode;
-                if (status === 403) {
-                    return { success: false, statusCode: 403, message: 'forbidden' } as unknown as IDataObject;
-                }
-                const msg = err instanceof Error ? err.message : String(err);
-                throw new NodeOperationError(this.getNode(), `Failed to execute deleteRemoteSupport: ${msg}`);
-            }
-        }
+			try {
+				const fullResponse = await this.helpers.httpRequest({
+					...(requestOptions as unknown as IDataObject),
+					simple: false,
+					resolveWithFullResponse: true,
+				} as unknown as import('n8n-workflow').IHttpRequestOptions);
+				if (fullResponse && fullResponse.statusCode === 204) {
+					return {
+						success: true,
+						statusCode: 204,
+						message: 'Remote support deleted',
+					} as unknown as IDataObject;
+				}
+				return fullResponse && fullResponse.body ? fullResponse.body : fullResponse;
+			} catch (err: unknown) {
+				const e = err as unknown as { statusCode?: number; response?: { statusCode?: number } };
+				const status = e?.statusCode ?? e?.response?.statusCode;
+				if (status === 403) {
+					return {
+						success: false,
+						statusCode: 403,
+						message: 'forbidden',
+					} as unknown as IDataObject;
+				}
+				const msg = err instanceof Error ? err.message : String(err);
+				throw new NodeOperationError(
+					this.getNode(),
+					`Failed to execute deleteRemoteSupport: ${msg}`,
+				);
+			}
+		}
 
-        default:
-            throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized.`);
-    }
+		default:
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized.`,
+			);
+	}
 
-    try {
-        const responseData = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-        return responseData;
-    } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new NodeOperationError(this.getNode(), `Failed to execute ${operation}: ${message}`);
-    }
+	try {
+		const responseData = await this.helpers.httpRequest(
+			requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+		);
+		return responseData;
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new NodeOperationError(this.getNode(), `Failed to execute ${operation}: ${message}`);
+	}
 }

--- a/nodes/tanss/sub/TicketContent.ts
+++ b/nodes/tanss/sub/TicketContent.ts
@@ -1,266 +1,280 @@
 import { IExecuteFunctions, INodeProperties, NodeOperationError, IDataObject } from 'n8n-workflow';
 
 export const ticketContentOperations: INodeProperties[] = [
-    {
-        displayName: 'Operation',
-        name: 'operation',
-        type: 'options' as const,
-        noDataExpression: true,
-        displayOptions: {
-            show: {
-                resource: ['ticketContent'],
-            },
-        },
-        options: [
-            {
-                name: 'Get Ticket Documents',
-                value: 'getTicketDocuments',
-                description: 'Gets all documents attached to a ticket (list)',
-                action: 'Get ticket documents',
-            },
-            {
-                name: 'Get Ticket Document',
-                value: 'getTicketDocument',
-                description: 'Generates a one-time download URL for a specific ticket document',
-                action: 'Get a ticket document',
-            },
-            {
-                name: 'Get Ticket Images',
-                value: 'getTicketImages',
-                description: 'Gets all images (screenshots) attached to a ticket (list)',
-                action: 'Get ticket images',
-            },
-            {
-                name: 'Get Ticket Image',
-                value: 'getTicketImage',
-                description: 'Generates a one-time download URL for a specific ticket image',
-                action: 'Get a ticket image',
-            },
-            {
-                name: 'Upload Document / Image',
-                value: 'uploadTicketContent',
-                description: 'Uploads a document or image into a ticket (multipart/form-data)',
-                action: 'Upload document or image to ticket',
-            },
-        ],
-        default: 'getTicketDocuments',
-    },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options' as const,
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['ticketContent'],
+			},
+		},
+		options: [
+			{
+				name: 'Get Ticket Documents',
+				value: 'getTicketDocuments',
+				description: 'Gets all documents attached to a ticket (list)',
+				action: 'Get ticket documents',
+			},
+			{
+				name: 'Get Ticket Document',
+				value: 'getTicketDocument',
+				description: 'Generates a one-time download URL for a specific ticket document',
+				action: 'Get a ticket document',
+			},
+			{
+				name: 'Get Ticket Images',
+				value: 'getTicketImages',
+				description: 'Gets all images (screenshots) attached to a ticket (list)',
+				action: 'Get ticket images',
+			},
+			{
+				name: 'Get Ticket Image',
+				value: 'getTicketImage',
+				description: 'Generates a one-time download URL for a specific ticket image',
+				action: 'Get a ticket image',
+			},
+			{
+				name: 'Upload Document / Image',
+				value: 'uploadTicketContent',
+				description: 'Uploads a document or image into a ticket (multipart/form-data)',
+				action: 'Upload document or image to ticket',
+			},
+		],
+		default: 'getTicketDocuments',
+	},
 ];
 
 export const ticketContentFields: INodeProperties[] = [
-    {
-        displayName: 'API Token',
-        name: 'apiToken',
-        type: 'string' as const,
-        required: true,
-        typeOptions: { password: true },
-        default: '',
-        description: 'API token obtained from the TANSS API login',
-        displayOptions: {
-            show: {
-                resource: ['ticketContent'],
-            },
-        },
-    },
-    {
-        displayName: 'Ticket ID',
-        name: 'ticketId',
-        type: 'number' as const,
-        displayOptions: {
-            show: {
-                resource: ['ticketContent'],
-            },
-        },
-        default: 0,
-        description: 'ID of the ticket',
-    },
-    {
-        displayName: 'Document ID',
-        name: 'documentId',
-        type: 'number' as const,
-        displayOptions: {
-            show: {
-                resource: ['ticketContent'],
-                operation: ['getTicketDocument'],
-            },
-        },
-        default: 0,
-        description: 'ID of the document to generate a one-time download URL for',
-    },
-    {
-        displayName: 'Image ID',
-        name: 'imageId',
-        type: 'number' as const,
-        displayOptions: {
-            show: {
-                resource: ['ticketContent'],
-                operation: ['getTicketImage'],
-            },
-        },
-        default: 0,
-        description: 'ID of the image to generate a one-time download URL for',
-    },
-    {
-        displayName: 'Binary Property Name',
-        name: 'binaryPropertyName',
-        type: 'string' as const,
-        default: 'data',
-        description: 'Name of the binary property that contains the file to upload',
-        displayOptions: {
-            show: {
-                resource: ['ticketContent'],
-                operation: ['uploadTicketContent'],
-            },
-        },
-    },
-    {
-        displayName: 'Descriptions',
-        name: 'descriptions',
-        type: 'string' as const,
-        default: '',
-        description: 'Description for the uploaded file(s) (if multiple, separate by newline)',
-        displayOptions: {
-            show: {
-                resource: ['ticketContent'],
-                operation: ['uploadTicketContent'],
-            },
-        },
-    },
+	{
+		displayName: 'API Token',
+		name: 'apiToken',
+		type: 'string' as const,
+		required: true,
+		typeOptions: { password: true },
+		default: '',
+		description: 'API token obtained from the TANSS API login',
+		displayOptions: {
+			show: {
+				resource: ['ticketContent'],
+			},
+		},
+	},
+	{
+		displayName: 'Ticket ID',
+		name: 'ticketId',
+		type: 'number' as const,
+		displayOptions: {
+			show: {
+				resource: ['ticketContent'],
+			},
+		},
+		default: 0,
+		description: 'ID of the ticket',
+	},
+	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'number' as const,
+		displayOptions: {
+			show: {
+				resource: ['ticketContent'],
+				operation: ['getTicketDocument'],
+			},
+		},
+		default: 0,
+		description: 'ID of the document to generate a one-time download URL for',
+	},
+	{
+		displayName: 'Image ID',
+		name: 'imageId',
+		type: 'number' as const,
+		displayOptions: {
+			show: {
+				resource: ['ticketContent'],
+				operation: ['getTicketImage'],
+			},
+		},
+		default: 0,
+		description: 'ID of the image to generate a one-time download URL for',
+	},
+	{
+		displayName: 'Binary Property Name',
+		name: 'binaryPropertyName',
+		type: 'string' as const,
+		default: 'data',
+		description: 'Name of the binary property that contains the file to upload',
+		displayOptions: {
+			show: {
+				resource: ['ticketContent'],
+				operation: ['uploadTicketContent'],
+			},
+		},
+	},
+	{
+		displayName: 'Descriptions',
+		name: 'descriptions',
+		type: 'string' as const,
+		default: '',
+		description: 'Description for the uploaded file(s) (if multiple, separate by newline)',
+		displayOptions: {
+			show: {
+				resource: ['ticketContent'],
+				operation: ['uploadTicketContent'],
+			},
+		},
+	},
 ];
 
 export async function handleTicketContent(this: IExecuteFunctions, i: number) {
-    const operation = this.getNodeParameter('operation', i) as string;
-    const supported = [
-        'getTicketDocuments',
-        'getTicketDocument',
-        'getTicketImages',
-        'getTicketImage',
-        'uploadTicketContent',
-    ] as const;
-    if (!supported.includes(operation as typeof supported[number])) {
-        throw new NodeOperationError(this.getNode(), `Operation "${operation}" not supported by TicketContent.`);
-    }
+	const operation = this.getNodeParameter('operation', i) as string;
+	const supported = [
+		'getTicketDocuments',
+		'getTicketDocument',
+		'getTicketImages',
+		'getTicketImage',
+		'uploadTicketContent',
+	] as const;
+	if (!supported.includes(operation as (typeof supported)[number])) {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Operation "${operation}" not supported by TicketContent.`,
+		);
+	}
 
-    const credentials = await this.getCredentials('tanssApi');
-    if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
+	const credentials = await this.getCredentials('tanssApi');
+	if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
 
-    const apiToken = this.getNodeParameter('apiToken', i, '') as string;
-    const ticketId = this.getNodeParameter('ticketId', i, 0) as number;
-    const typedCredentials = credentials as { baseURL?: string };
-    const baseURL = typedCredentials.baseURL;
-    if (!baseURL) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
-    if (!ticketId || ticketId <= 0) throw new NodeOperationError(this.getNode(), 'Valid Ticket ID is required.');
+	const apiToken = this.getNodeParameter('apiToken', i, '') as string;
+	const ticketId = this.getNodeParameter('ticketId', i, 0) as number;
+	const typedCredentials = credentials as { baseURL?: string };
+	const baseURL = typedCredentials.baseURL;
+	if (!baseURL) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
+	if (!ticketId || ticketId <= 0)
+		throw new NodeOperationError(this.getNode(), 'Valid Ticket ID is required.');
 
-    let url = '';
-    const requestOptions: IDataObject = {
-        method: 'GET',
-        url: '',
-        headers: { apiToken, 'Content-Type': 'application/json' },
-        json: true,
-    };
+	let url = '';
+	const requestOptions: IDataObject = {
+		method: 'GET',
+		url: '',
+		headers: { apiToken, 'Content-Type': 'application/json' },
+		json: true,
+	};
 
-    
+	if (operation === 'getTicketDocuments') {
+		url = `${baseURL}/backend/api/v1/tickets/${ticketId}/documents`;
+	} else if (operation === 'getTicketDocument') {
+		const documentId = this.getNodeParameter('documentId', i, 0) as number;
+		if (!documentId || documentId <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid Document ID is required.');
+		url = `${baseURL}/backend/api/v1/tickets/${ticketId}/documents/${documentId}`;
+	} else if (operation === 'getTicketImages') {
+		url = `${baseURL}/backend/api/v1/tickets/${ticketId}/screenshots`;
+	} else if (operation === 'getTicketImage') {
+		const imageId = this.getNodeParameter('imageId', i, 0) as number;
+		if (!imageId || imageId <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid Image ID is required.');
+		url = `${baseURL}/backend/api/v1/tickets/${ticketId}/screenshots/${imageId}`;
+	} else {
+		const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i, 'data') as string;
+		const descriptionsParam = this.getNodeParameter('descriptions', i, '') as string;
 
-    if (operation === 'getTicketDocuments') {
-        url = `${baseURL}/backend/api/v1/tickets/${ticketId}/documents`;
-    } else if (operation === 'getTicketDocument') {
-        const documentId = this.getNodeParameter('documentId', i, 0) as number;
-        if (!documentId || documentId <= 0) throw new NodeOperationError(this.getNode(), 'Valid Document ID is required.');
-        url = `${baseURL}/backend/api/v1/tickets/${ticketId}/documents/${documentId}`;
-    } else if (operation === 'getTicketImages') {
-        url = `${baseURL}/backend/api/v1/tickets/${ticketId}/screenshots`;
-    } else if (operation === 'getTicketImage') {
-        const imageId = this.getNodeParameter('imageId', i, 0) as number;
-        if (!imageId || imageId <= 0) throw new NodeOperationError(this.getNode(), 'Valid Image ID is required.');
-        url = `${baseURL}/backend/api/v1/tickets/${ticketId}/screenshots/${imageId}`;
-    } else {
-        const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i, 'data') as string;
-        const descriptionsParam = this.getNodeParameter('descriptions', i, '') as string;
+		const items = this.getInputData();
+		const item = items[i];
+		if (!item.binary || !item.binary[binaryPropertyName]) {
+			throw new NodeOperationError(
+				this.getNode(),
+				`No binary found on item index ${i} with property name "${binaryPropertyName}"`,
+			);
+		}
 
-        const items = this.getInputData();
-        const item = items[i];
-        if (!item.binary || !item.binary[binaryPropertyName]) {
-            throw new NodeOperationError(this.getNode(), `No binary found on item index ${i} with property name "${binaryPropertyName}"`);
-        }
+		const binaryEntry = item.binary[binaryPropertyName] as {
+			fileName?: string;
+			data: string;
+			mimeType?: string;
+		};
 
-        const binaryEntry = item.binary[binaryPropertyName] as {
-            fileName?: string;
-            data: string;
-            mimeType?: string;
-        };
+		if (!binaryEntry || typeof binaryEntry.data !== 'string') {
+			throw new NodeOperationError(this.getNode(), 'Binary data malformed or missing.');
+		}
 
-        if (!binaryEntry || typeof binaryEntry.data !== 'string') {
-            throw new NodeOperationError(this.getNode(), 'Binary data malformed or missing.');
-        }
+		let BufferCtor: { from: (data: string, encoding?: string) => Uint8Array } | undefined;
+		if (
+			typeof Buffer !== 'undefined' &&
+			typeof (Buffer as unknown as { from?: unknown }).from === 'function'
+		) {
+			BufferCtor = Buffer as unknown as { from: (data: string, encoding?: string) => Uint8Array };
+		}
+		if (BufferCtor === undefined) {
+			throw new NodeOperationError(this.getNode(), 'Buffer is not available in this runtime.');
+		}
+		const fileBuffer = BufferCtor.from(binaryEntry.data, 'base64');
 
-        let BufferCtor: { from: (data: string, encoding?: string) => Uint8Array } | undefined;
-        if (typeof Buffer !== 'undefined' && typeof (Buffer as unknown as { from?: unknown }).from === 'function') {
-            BufferCtor = Buffer as unknown as { from: (data: string, encoding?: string) => Uint8Array };
-        }
-        if (BufferCtor === undefined) {
-            throw new NodeOperationError(this.getNode(), 'Buffer is not available in this runtime.');
-        }
-        const fileBuffer = BufferCtor.from(binaryEntry.data, 'base64');
+		const fileName = binaryEntry.fileName ?? 'file';
+		const contentType = binaryEntry.mimeType ?? 'application/octet-stream';
 
-        const fileName = binaryEntry.fileName ?? 'file';
-        const contentType = binaryEntry.mimeType ?? 'application/octet-stream';
+		url = `${baseURL}/backend/api/v1/tickets/${ticketId}/upload`;
+		const boundary = `----n8nBoundary${Date.now()}`;
+		const crlf = '\r\n';
+		const delimiter = `--${boundary}${crlf}`;
+		const closeDelimiter = `${crlf}--${boundary}--${crlf}`;
 
-    
+		const filePartHeader =
+			`Content-Disposition: form-data; name="files"; filename="${fileName}"${crlf}` +
+			`Content-Type: ${contentType}${crlf}${crlf}`;
 
-        url = `${baseURL}/backend/api/v1/tickets/${ticketId}/upload`;
-        const boundary = `----n8nBoundary${Date.now()}`;
-        const crlf = '\r\n';
-        const delimiter = `--${boundary}${crlf}`;
-        const closeDelimiter = `${crlf}--${boundary}--${crlf}`;
+		const descPartHeader = `${crlf}--${boundary}${crlf}Content-Disposition: form-data; name="descriptions"${crlf}${crlf}`;
 
-        const filePartHeader = `Content-Disposition: form-data; name="files"; filename="${fileName}"${crlf}` +
-            `Content-Type: ${contentType}${crlf}${crlf}`;
+		const preamble = Buffer.from(delimiter + filePartHeader, 'utf8');
+		const postamble = Buffer.from(descPartHeader + descriptionsParam + closeDelimiter, 'utf8');
 
-        const descPartHeader = `${crlf}--${boundary}${crlf}Content-Disposition: form-data; name="descriptions"${crlf}${crlf}`;
+		const bodyBuffer = Buffer.concat([preamble, fileBuffer, postamble]);
 
-        const preamble = Buffer.from(delimiter + filePartHeader, 'utf8');
-        const postamble = Buffer.from(descPartHeader + descriptionsParam + closeDelimiter, 'utf8');
+		const headers: IDataObject = {
+			apiToken,
+			'Content-Type': `multipart/form-data; boundary=${boundary}`,
+			'Content-Length': String(bodyBuffer.length),
+		};
 
-        const bodyBuffer = Buffer.concat([preamble, fileBuffer, postamble]);
+		Object.assign(requestOptions, {
+			method: 'POST',
+			url,
+			headers,
+			body: bodyBuffer,
+			json: false,
+		});
+	}
 
-        const headers: IDataObject = {
-            apiToken,
-            'Content-Type': `multipart/form-data; boundary=${boundary}`,
-            'Content-Length': String(bodyBuffer.length),
-        };
+	if (operation !== 'uploadTicketContent') {
+		requestOptions.url = url;
+	}
 
-        Object.assign(requestOptions, {
-            method: 'POST',
-            url,
-            headers,
-            body: bodyBuffer,
-            json: false,
-        });
-    }
-
-    if (operation !== 'uploadTicketContent') {
-        requestOptions.url = url;
-    }
-
-    try {
-        const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-        return response;
-    } catch (error: unknown) {
-        const err = error as unknown as { response?: unknown; statusCode?: number; message?: string };
-        const resp = err.response as unknown as Record<string, unknown> | undefined;
-        const respBody = resp?.body ?? resp?.data ?? resp;
-        const status = resp?.status ?? err.statusCode ?? undefined;
-        const message = err?.message ?? (error instanceof Error ? error.message : String(error));
-        let extra = '';
-        try {
-            if (respBody !== undefined) {
-                const serialized = typeof respBody === 'string' ? respBody : JSON.stringify(respBody);
-                extra = ` ResponseBody: ${serialized}`;
-            }
-        } catch {
-            // nothing here
-        }
-        const statusTxt = status ? ` Status: ${status}.` : '';
-        throw new NodeOperationError(this.getNode(), `Failed to fetch ticket content: ${message}.${statusTxt}${extra}`);
-    }
+	try {
+		const response = await this.helpers.httpRequest(
+			requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+		);
+		return response;
+	} catch (error: unknown) {
+		const err = error as unknown as { response?: unknown; statusCode?: number; message?: string };
+		const resp = err.response as unknown as Record<string, unknown> | undefined;
+		const respBody = resp?.body ?? resp?.data ?? resp;
+		const status = resp?.status ?? err.statusCode ?? undefined;
+		const message = err?.message ?? (error instanceof Error ? error.message : String(error));
+		let extra = '';
+		try {
+			if (respBody !== undefined) {
+				const serialized = typeof respBody === 'string' ? respBody : JSON.stringify(respBody);
+				extra = ` ResponseBody: ${serialized}`;
+			}
+		} catch {
+			// nothing here
+		}
+		const statusTxt = status ? ` Status: ${status}.` : '';
+		throw new NodeOperationError(
+			this.getNode(),
+			`Failed to fetch ticket content: ${message}.${statusTxt}${extra}`,
+		);
+	}
 }

--- a/nodes/tanss/sub/TicketLists.ts
+++ b/nodes/tanss/sub/TicketLists.ts
@@ -120,10 +120,33 @@ export const ticketListFields: INodeProperties[] = [
 		default: {},
 		placeholder: 'Add Field',
 		options: [
-			{ displayName: 'Companies', name: 'companies', type: 'string' as const, typeOptions: { multipleValues: true }, default: [] },
-			{ displayName: 'Departments', name: 'departments', type: 'string' as const, typeOptions: { multipleValues: true }, default: [] },
-			{ displayName: 'IDs', name: 'ids', type: 'string' as const, typeOptions: { multipleValues: true }, default: [] },
-			{ displayName: 'Include Done Tickets', name: 'includeDoneTickets', type: 'boolean' as const, default: false },
+			{
+				displayName: 'Companies',
+				name: 'companies',
+				type: 'string' as const,
+				typeOptions: { multipleValues: true },
+				default: [],
+			},
+			{
+				displayName: 'Departments',
+				name: 'departments',
+				type: 'string' as const,
+				typeOptions: { multipleValues: true },
+				default: [],
+			},
+			{
+				displayName: 'IDs',
+				name: 'ids',
+				type: 'string' as const,
+				typeOptions: { multipleValues: true },
+				default: [],
+			},
+			{
+				displayName: 'Include Done Tickets',
+				name: 'includeDoneTickets',
+				type: 'boolean' as const,
+				default: false,
+			},
 			{ displayName: 'Is Repair', name: 'isRepair', type: 'boolean' as const, default: false },
 			{ displayName: 'Items Per Page', name: 'itemsPerPage', type: 'number' as const, default: 20 },
 			{
@@ -137,20 +160,56 @@ export const ticketListFields: INodeProperties[] = [
 						name: 'timeframe',
 						displayName: 'Timeframe',
 						values: [
-							{ displayName: 'From', name: 'from', type: 'number' as const, default: 0, description: 'Unix timestamp of the "from" date' },
-							{ displayName: 'To', name: 'to', type: 'number' as const, default: 0, description: 'Unix timestamp of the "to" date' },
+							{
+								displayName: 'From',
+								name: 'from',
+								type: 'number' as const,
+								default: 0,
+								description: 'Unix timestamp of the "from" date',
+							},
+							{
+								displayName: 'To',
+								name: 'to',
+								type: 'number' as const,
+								default: 0,
+								description: 'Unix timestamp of the "to" date',
+							},
 						],
 					},
 				],
 			},
-			{ displayName: 'Not Assigned To Employees', name: 'notAssignedToEmployees', type: 'multiOptions' as const, typeOptions: { multipleValues: true }, default: [] },
+			{
+				displayName: 'Not Assigned To Employees',
+				name: 'notAssignedToEmployees',
+				type: 'multiOptions' as const,
+				typeOptions: { multipleValues: true },
+				default: [],
+			},
 			{ displayName: 'Page', name: 'page', type: 'number' as const, default: 1 },
 			{ displayName: 'Phase ID', name: 'phaseId', type: 'number' as const, default: 0 },
 			{ displayName: 'Project ID', name: 'projectId', type: 'number' as const, default: 0 },
 			{ displayName: 'Remitter ID', name: 'remitterId', type: 'number' as const, default: 0 },
-			{ displayName: 'Staff', name: 'staff', type: 'string' as const, typeOptions: { multipleValues: true }, default: [] },
-			{ displayName: 'States', name: 'states', type: 'multiOptions' as const, typeOptions: { multipleValues: true }, default: [] },
-			{ displayName: 'Types', name: 'types', type: 'multiOptions' as const, typeOptions: { multipleValues: true }, default: [] },
+			{
+				displayName: 'Staff',
+				name: 'staff',
+				type: 'string' as const,
+				typeOptions: { multipleValues: true },
+				default: [],
+			},
+			{
+				displayName: 'States',
+				name: 'states',
+				type: 'multiOptions' as const,
+				typeOptions: { multipleValues: true },
+				default: [],
+			},
+			{
+				displayName: 'Types',
+				name: 'types',
+				type: 'multiOptions' as const,
+				typeOptions: { multipleValues: true },
+				default: [],
+			},
 		],
 	},
 ];
@@ -213,19 +272,27 @@ export async function handleTicketList(this: IExecuteFunctions, i: number) {
 			break;
 		case 'getCustomTicketList': {
 			url = `${credentials.baseURL}/backend/api/v1/tickets`;
-			const customTicketQuery = this.getNodeParameter('customTicketQuery', i, {}) as Record<string, unknown>;
+			const customTicketQuery = this.getNodeParameter('customTicketQuery', i, {}) as Record<
+				string,
+				unknown
+			>;
 			requestOptions.method = 'PUT';
 			requestOptions.body = customTicketQuery;
 			break;
 		}
 		default:
-			throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized.`);
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized.`,
+			);
 	}
 
 	requestOptions.url = url;
 
 	try {
-		const responseData = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
+		const responseData = await this.helpers.httpRequest(
+			requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+		);
 		return responseData;
 	} catch (error: unknown) {
 		const errorMessage = error instanceof Error ? error.message : String(error);

--- a/nodes/tanss/sub/TicketSates.ts
+++ b/nodes/tanss/sub/TicketSates.ts
@@ -1,267 +1,292 @@
-import { IExecuteFunctions, INodeProperties, NodeOperationError, IDataObject, IHttpRequestOptions } from 'n8n-workflow';
+import {
+	IExecuteFunctions,
+	INodeProperties,
+	NodeOperationError,
+	IDataObject,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
 
 export const ticketStatesOperations: INodeProperties[] = [
-    {
-        displayName: 'Operation',
-        name: 'operation',
-        type: 'options' as const,
-        noDataExpression: true,
-        displayOptions: {
-            show: {
-                resource: ['ticketStates'],
-            },
-        },
-        options: [
-            {
-                name: 'Get Ticket States',
-                value: 'getTicketStates',
-                description: 'Gets a list of all ticket states',
-                action: 'Get ticket states',
-            },
-            {
-                name: 'Create Ticket State',
-                value: 'createTicketState',
-                description: 'Creates a new ticket state',
-                action: 'Create a ticket state',
-            },
-            {
-                name: 'Update Ticket State',
-                value: 'updateTicketState',
-                description: 'Updates an existing ticket state',
-                action: 'Update a ticket state',
-            },
-            {
-                name: 'Delete Ticket State',
-                value: 'deleteTicketState',
-                description: 'Deletes a ticket state',
-                action: 'Delete a ticket state',
-            },
-        ],
-        default: 'getTicketStates',
-    },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options' as const,
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['ticketStates'],
+			},
+		},
+		options: [
+			{
+				name: 'Get Ticket States',
+				value: 'getTicketStates',
+				description: 'Gets a list of all ticket states',
+				action: 'Get ticket states',
+			},
+			{
+				name: 'Create Ticket State',
+				value: 'createTicketState',
+				description: 'Creates a new ticket state',
+				action: 'Create a ticket state',
+			},
+			{
+				name: 'Update Ticket State',
+				value: 'updateTicketState',
+				description: 'Updates an existing ticket state',
+				action: 'Update a ticket state',
+			},
+			{
+				name: 'Delete Ticket State',
+				value: 'deleteTicketState',
+				description: 'Deletes a ticket state',
+				action: 'Delete a ticket state',
+			},
+		],
+		default: 'getTicketStates',
+	},
 ];
 
 export const ticketStatesFields: INodeProperties[] = [
-    {
-        displayName: 'API Token',
-        name: 'apiToken',
-        type: 'string' as const,
-        required: true,
-        typeOptions: { password: true },
-        default: '',
-        description: 'API token obtained from the TANSS API login',
-        displayOptions: {
-            show: {
-                resource: ['ticketStates'],
-            },
-        },
-    },
-    // ID field used by update/delete (single fetch removed)
-    {
-        displayName: 'Ticket State ID',
-        name: 'id',
-        type: 'number' as const,
-        default: 0,
-        description: 'ID of the ticket state',
-        displayOptions: {
-            show: {
-                resource: ['ticketStates'],
-                operation: ['updateTicketState', 'deleteTicketState'],
-            },
-        },
-    },
-    // Fields for creating or updating a ticket state
-    {
-        displayName: 'Name',
-        name: 'name',
-        type: 'string' as const,
-        default: '',
-        required: true,
-        displayOptions: {
-            show: {
-                resource: ['ticketStates'],
-                operation: ['createTicketState', 'updateTicketState'],
-            },
-        },
-        description: 'Name of the ticket state',
-    },
-    {
-        displayName: 'Image',
-        name: 'image',
-        type: 'string' as const,
-        default: '',
-        displayOptions: {
-            show: {
-                resource: ['ticketStates'],
-                operation: ['createTicketState', 'updateTicketState'],
-            },
-        },
-        description: 'Name of the image (must be in folder media/hp/bug_status)',
-    },
-    {
-        displayName: 'Wait State',
-        name: 'waitState',
-        type: 'boolean' as const,
-        default: false,
-        displayOptions: {
-            show: {
-                resource: ['ticketStates'],
-                operation: ['createTicketState', 'updateTicketState'],
-            },
-        },
-        description: 'Determines if this state is a waiting state',
-    },
-    {
-        displayName: 'Rank',
-        name: 'rank',
-        type: 'number' as const,
-        default: 0,
-        displayOptions: {
-            show: {
-                resource: ['ticketStates'],
-                operation: ['createTicketState', 'updateTicketState'],
-            },
-        },
-        description: 'Rank of this state (position in lists)',
-    },
-    {
-        displayName: 'Active',
-        name: 'active',
-        type: 'boolean' as const,
-        default: true,
-        displayOptions: {
-            show: {
-                resource: ['ticketStates'],
-                operation: ['createTicketState', 'updateTicketState'],
-            },
-        },
-        description: "Is this an active state? (otherwise won't be shown)",
-    },
+	{
+		displayName: 'API Token',
+		name: 'apiToken',
+		type: 'string' as const,
+		required: true,
+		typeOptions: { password: true },
+		default: '',
+		description: 'API token obtained from the TANSS API login',
+		displayOptions: {
+			show: {
+				resource: ['ticketStates'],
+			},
+		},
+	},
+	// ID field used by update/delete (single fetch removed)
+	{
+		displayName: 'Ticket State ID',
+		name: 'id',
+		type: 'number' as const,
+		default: 0,
+		description: 'ID of the ticket state',
+		displayOptions: {
+			show: {
+				resource: ['ticketStates'],
+				operation: ['updateTicketState', 'deleteTicketState'],
+			},
+		},
+	},
+	// Fields for creating or updating a ticket state
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string' as const,
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['ticketStates'],
+				operation: ['createTicketState', 'updateTicketState'],
+			},
+		},
+		description: 'Name of the ticket state',
+	},
+	{
+		displayName: 'Image',
+		name: 'image',
+		type: 'string' as const,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['ticketStates'],
+				operation: ['createTicketState', 'updateTicketState'],
+			},
+		},
+		description: 'Name of the image (must be in folder media/hp/bug_status)',
+	},
+	{
+		displayName: 'Wait State',
+		name: 'waitState',
+		type: 'boolean' as const,
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['ticketStates'],
+				operation: ['createTicketState', 'updateTicketState'],
+			},
+		},
+		description: 'Determines if this state is a waiting state',
+	},
+	{
+		displayName: 'Rank',
+		name: 'rank',
+		type: 'number' as const,
+		default: 0,
+		displayOptions: {
+			show: {
+				resource: ['ticketStates'],
+				operation: ['createTicketState', 'updateTicketState'],
+			},
+		},
+		description: 'Rank of this state (position in lists)',
+	},
+	{
+		displayName: 'Active',
+		name: 'active',
+		type: 'boolean' as const,
+		default: true,
+		displayOptions: {
+			show: {
+				resource: ['ticketStates'],
+				operation: ['createTicketState', 'updateTicketState'],
+			},
+		},
+		description: "Is this an active state? (otherwise won't be shown)",
+	},
 ];
 
 export async function handleTicketStates(this: IExecuteFunctions, i: number) {
-    const operation = this.getNodeParameter('operation', i) as string;
-    const allowed = ['getTicketStates', 'createTicketState', 'updateTicketState', 'deleteTicketState'] as const;
-    if (!allowed.includes(operation as typeof allowed[number])) {
-        throw new NodeOperationError(this.getNode(), `Operation "${operation}" not supported by TicketStates.`);
-    }
+	const operation = this.getNodeParameter('operation', i) as string;
+	const allowed = [
+		'getTicketStates',
+		'createTicketState',
+		'updateTicketState',
+		'deleteTicketState',
+	] as const;
+	if (!allowed.includes(operation as (typeof allowed)[number])) {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Operation "${operation}" not supported by TicketStates.`,
+		);
+	}
 
-    const credentials = await this.getCredentials('tanssApi');
-    if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
+	const credentials = await this.getCredentials('tanssApi');
+	if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
 
-    const apiToken = this.getNodeParameter('apiToken', i, '') as string;
-    const typedCredentials = credentials as { baseURL?: string };
-    const baseURL = typedCredentials.baseURL;
-    if (!baseURL) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
+	const apiToken = this.getNodeParameter('apiToken', i, '') as string;
+	const typedCredentials = credentials as { baseURL?: string };
+	const baseURL = typedCredentials.baseURL;
+	if (!baseURL) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
 
-    // GET list
-    if (operation === 'getTicketStates') {
-        const url = `${baseURL}/backend/api/v1/admin/ticketStates`;
-        const requestOptions: IDataObject = {
-            method: 'GET',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            json: true,
-        };
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to fetch ticket states: ${message}`);
-        }
-    }
+	// GET list
+	if (operation === 'getTicketStates') {
+		const url = `${baseURL}/backend/api/v1/admin/ticketStates`;
+		const requestOptions: IDataObject = {
+			method: 'GET',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			json: true,
+		};
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to fetch ticket states: ${message}`);
+		}
+	}
 
-    // CREATE
-    if (operation === 'createTicketState') {
-        const name = this.getNodeParameter('name', i) as string;
-        if (!name) throw new NodeOperationError(this.getNode(), 'Name is required to create a ticket state.');
-        const image = this.getNodeParameter('image', i, '') as string;
-        const waitState = this.getNodeParameter('waitState', i, false) as boolean;
-        const rank = this.getNodeParameter('rank', i, 0) as number;
-        const active = this.getNodeParameter('active', i, true) as boolean;
+	// CREATE
+	if (operation === 'createTicketState') {
+		const name = this.getNodeParameter('name', i) as string;
+		if (!name)
+			throw new NodeOperationError(this.getNode(), 'Name is required to create a ticket state.');
+		const image = this.getNodeParameter('image', i, '') as string;
+		const waitState = this.getNodeParameter('waitState', i, false) as boolean;
+		const rank = this.getNodeParameter('rank', i, 0) as number;
+		const active = this.getNodeParameter('active', i, true) as boolean;
 
-        const body: IDataObject = {
-            name,
-            image,
-            waitState,
-            rank,
-            active,
-        };
+		const body: IDataObject = {
+			name,
+			image,
+			waitState,
+			rank,
+			active,
+		};
 
-        const url = `${baseURL}/backend/api/v1/admin/ticketStates`;
-        const requestOptions: IDataObject = {
-            method: 'POST',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            body,
-            json: true,
-        };
+		const url = `${baseURL}/backend/api/v1/admin/ticketStates`;
+		const requestOptions: IDataObject = {
+			method: 'POST',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to create ticket state: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to create ticket state: ${message}`);
+		}
+	}
 
-    // UPDATE
-    if (operation === 'updateTicketState') {
-        const id = this.getNodeParameter('id', i, 0) as number;
-        if (!id || id <= 0) throw new NodeOperationError(this.getNode(), 'Valid ID is required to update.');
-        const name = this.getNodeParameter('name', i, '') as string;
-        const image = this.getNodeParameter('image', i, '') as string;
-        const waitState = this.getNodeParameter('waitState', i, false) as boolean;
-        const rank = this.getNodeParameter('rank', i, 0) as number;
-        const active = this.getNodeParameter('active', i, true) as boolean;
+	// UPDATE
+	if (operation === 'updateTicketState') {
+		const id = this.getNodeParameter('id', i, 0) as number;
+		if (!id || id <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid ID is required to update.');
+		const name = this.getNodeParameter('name', i, '') as string;
+		const image = this.getNodeParameter('image', i, '') as string;
+		const waitState = this.getNodeParameter('waitState', i, false) as boolean;
+		const rank = this.getNodeParameter('rank', i, 0) as number;
+		const active = this.getNodeParameter('active', i, true) as boolean;
 
-        const body: IDataObject = {
-            name,
-            image,
-            waitState,
-            rank,
-            active,
-        };
+		const body: IDataObject = {
+			name,
+			image,
+			waitState,
+			rank,
+			active,
+		};
 
-        const url = `${baseURL}/backend/api/v1/admin/ticketStates/${id}`;
-        const requestOptions: IDataObject = {
-            method: 'PUT',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            body,
-            json: true,
-        };
+		const url = `${baseURL}/backend/api/v1/admin/ticketStates/${id}`;
+		const requestOptions: IDataObject = {
+			method: 'PUT',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to update ticket state: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to update ticket state: ${message}`);
+		}
+	}
 
-    // DELETE
-    if (operation === 'deleteTicketState') {
-        const id = this.getNodeParameter('id', i, 0) as number;
-        if (!id || id <= 0) throw new NodeOperationError(this.getNode(), 'Valid ID is required to delete.');
-        const url = `${baseURL}/backend/api/v1/admin/ticketStates/${id}`;
-        const requestOptions: IDataObject = {
-            method: 'DELETE',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            json: true,
-        };
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to delete ticket state: ${message}`);
-        }
-    }
+	// DELETE
+	if (operation === 'deleteTicketState') {
+		const id = this.getNodeParameter('id', i, 0) as number;
+		if (!id || id <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid ID is required to delete.');
+		const url = `${baseURL}/backend/api/v1/admin/ticketStates/${id}`;
+		const requestOptions: IDataObject = {
+			method: 'DELETE',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			json: true,
+		};
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to delete ticket state: ${message}`);
+		}
+	}
 
-    throw new NodeOperationError(this.getNode(), 'Unhandled operation');
+	throw new NodeOperationError(this.getNode(), 'Unhandled operation');
 }

--- a/nodes/tanss/sub/Tickets.ts
+++ b/nodes/tanss/sub/Tickets.ts
@@ -12,13 +12,48 @@ export const ticketOperations: INodeProperties[] = [
 			},
 		},
 		options: [
-			{ name: 'Create Comment', value: 'createComment', description: 'Creates a comment for a specific ticket', action: 'Creates a comment for a specific ticket' },
-			{ name: 'Create Ticket', value: 'createTicket', description: 'Creates a new Ticket in TANSS', action: 'Creates a new ticket' },
-			{ name: 'Delete Ticket', value: 'deleteTicket', description: 'Deletes a ticket', action: 'Deletes a ticket' },
-			{ name: 'Get Ticket by ID', value: 'getTicketById', description: 'Fetches a ticket by ID', action: 'Fetches a ticket by ID' },
-			{ name: 'Get Ticket History', value: 'getTicketHistory', description: 'Fetches the history of a ticket', action: 'Fetches the history of a ticket' },
-			{ name: 'Merge Tickets', value: 'mergeTickets', description: 'Merges one ticket into another', action: 'Merges one ticket into another' },
-			{ name: 'Update Ticket', value: 'updateTicket', description: 'Updates a ticket with the provided details', action: 'Updates a ticket with the provided details' },
+			{
+				name: 'Create Comment',
+				value: 'createComment',
+				description: 'Creates a comment for a specific ticket',
+				action: 'Creates a comment for a specific ticket',
+			},
+			{
+				name: 'Create Ticket',
+				value: 'createTicket',
+				description: 'Creates a new Ticket in TANSS',
+				action: 'Creates a new ticket',
+			},
+			{
+				name: 'Delete Ticket',
+				value: 'deleteTicket',
+				description: 'Deletes a ticket',
+				action: 'Deletes a ticket',
+			},
+			{
+				name: 'Get Ticket by ID',
+				value: 'getTicketById',
+				description: 'Fetches a ticket by ID',
+				action: 'Fetches a ticket by ID',
+			},
+			{
+				name: 'Get Ticket History',
+				value: 'getTicketHistory',
+				description: 'Fetches the history of a ticket',
+				action: 'Fetches the history of a ticket',
+			},
+			{
+				name: 'Merge Tickets',
+				value: 'mergeTickets',
+				description: 'Merges one ticket into another',
+				action: 'Merges one ticket into another',
+			},
+			{
+				name: 'Update Ticket',
+				value: 'updateTicket',
+				description: 'Updates a ticket with the provided details',
+				action: 'Updates a ticket with the provided details',
+			},
 		],
 		default: 'getTicketById',
 	},
@@ -124,8 +159,18 @@ export const ticketFields: INodeProperties[] = [
 		},
 		default: {},
 		options: [
-			{ displayName: 'Assigned to Department ID', name: 'assignedToDepartmentId', type: 'number' as const, default: 0 },
-			{ displayName: 'Assigned to Employee ID', name: 'assignedToEmployeeId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Assigned to Department ID',
+				name: 'assignedToDepartmentId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Assigned to Employee ID',
+				name: 'assignedToEmployeeId',
+				type: 'number' as const,
+				default: 0,
+			},
 			{
 				displayName: 'Attention',
 				name: 'attention',
@@ -142,8 +187,18 @@ export const ticketFields: INodeProperties[] = [
 			{ displayName: 'Content', name: 'content', type: 'string' as const, default: '' },
 			{ displayName: 'Deadline Date', name: 'deadlineDate', type: 'number' as const, default: 0 },
 			{ displayName: 'Due Date', name: 'dueDate', type: 'number' as const, default: 0 },
-			{ displayName: 'Estimated Minutes', name: 'estimatedMinutes', type: 'number' as const, default: 0 },
-			{ displayName: 'External Ticket ID', name: 'extTicketId', type: 'string' as const, default: '' },
+			{
+				displayName: 'Estimated Minutes',
+				name: 'estimatedMinutes',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'External Ticket ID',
+				name: 'extTicketId',
+				type: 'string' as const,
+				default: '',
+			},
 			{
 				displayName: 'Installation Fee',
 				name: 'installationFee',
@@ -157,10 +212,25 @@ export const ticketFields: INodeProperties[] = [
 			},
 			{ displayName: 'Order Number', name: 'orderNumber', type: 'string' as const, default: '' },
 			{ displayName: 'Phase ID', name: 'phaseId', type: 'number' as const, default: 0 },
-			{ displayName: 'Relationship Link ID', name: 'relationshipLinkId', type: 'number' as const, default: 0 },
-			{ displayName: 'Relationship Link Type ID', name: 'relationshipLinkTypeId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Relationship Link ID',
+				name: 'relationshipLinkId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Relationship Link Type ID',
+				name: 'relationshipLinkTypeId',
+				type: 'number' as const,
+				default: 0,
+			},
 			{ displayName: 'Remitter ID', name: 'remitterId', type: 'number' as const, default: 0 },
-			{ displayName: 'Resubmission Date', name: 'resubmissionDate', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Resubmission Date',
+				name: 'resubmissionDate',
+				type: 'number' as const,
+				default: 0,
+			},
 			{ displayName: 'Status ID', name: 'statusId', type: 'number' as const, default: 0 },
 			{ displayName: 'Title', name: 'title', type: 'string' as const, default: '' },
 			{ displayName: 'Type ID', name: 'typeId', type: 'number' as const, default: 0 },
@@ -179,8 +249,18 @@ export const ticketFields: INodeProperties[] = [
 		},
 		default: {},
 		options: [
-			{ displayName: 'Assigned to Department ID', name: 'assignedToDepartmentId', type: 'number' as const, default: 0 },
-			{ displayName: 'Assigned to Employee ID', name: 'assignedToEmployeeId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Assigned to Department ID',
+				name: 'assignedToDepartmentId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Assigned to Employee ID',
+				name: 'assignedToEmployeeId',
+				type: 'number' as const,
+				default: 0,
+			},
 			{
 				displayName: 'Attention',
 				name: 'attention',
@@ -206,10 +286,25 @@ export const ticketFields: INodeProperties[] = [
 			},
 			{ displayName: 'Company ID', name: 'companyId', type: 'number' as const, default: 0 },
 			{ displayName: 'Content', name: 'content', type: 'string' as const, default: '' },
-			{ displayName: 'Deadline Date (Timestamp)', name: 'deadlineDate', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Deadline Date (Timestamp)',
+				name: 'deadlineDate',
+				type: 'number' as const,
+				default: 0,
+			},
 			{ displayName: 'Due Date (Timestamp)', name: 'dueDate', type: 'number' as const, default: 0 },
-			{ displayName: 'Estimated Minutes', name: 'estimatedMinutes', type: 'number' as const, default: 0 },
-			{ displayName: 'External Ticket ID', name: 'extTicketId', type: 'string' as const, default: '' },
+			{
+				displayName: 'Estimated Minutes',
+				name: 'estimatedMinutes',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'External Ticket ID',
+				name: 'extTicketId',
+				type: 'string' as const,
+				default: '',
+			},
 			{
 				displayName: 'Installation Fee',
 				name: 'installationFee',
@@ -221,7 +316,12 @@ export const ticketFields: INodeProperties[] = [
 				],
 				default: 'NO',
 			},
-			{ displayName: 'Installation Fee Amount', name: 'installationFeeAmount', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Installation Fee Amount',
+				name: 'installationFeeAmount',
+				type: 'number' as const,
+				default: 0,
+			},
 			{
 				displayName: 'Installation Fee Drive Mode',
 				name: 'installationFeeDriveMode',
@@ -235,7 +335,12 @@ export const ticketFields: INodeProperties[] = [
 			},
 			{ displayName: 'Link ID', name: 'linkId', type: 'number' as const, default: 0 },
 			{ displayName: 'Link Type ID', name: 'linkTypeId', type: 'number' as const, default: 0 },
-			{ displayName: 'Local Ticket Admin Employee ID', name: 'localTicketAdminEmployeeId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Local Ticket Admin Employee ID',
+				name: 'localTicketAdminEmployeeId',
+				type: 'number' as const,
+				default: 0,
+			},
 			{
 				displayName: 'Local Ticket Admin Flag',
 				name: 'localTicketAdminFlag',
@@ -252,15 +357,50 @@ export const ticketFields: INodeProperties[] = [
 			{ displayName: 'Phase ID', name: 'phaseId', type: 'number' as const, default: 0 },
 			{ displayName: 'Project', name: 'project', type: 'boolean' as const, default: false },
 			{ displayName: 'Project ID', name: 'projectId', type: 'number' as const, default: 0 },
-			{ displayName: 'Relationship Link ID', name: 'relationshipLinkId', type: 'number' as const, default: 0 },
-			{ displayName: 'Relationship Link Type ID', name: 'relationshipLinkTypeId', type: 'number' as const, default: 0 },
-			{ displayName: 'Reminder (Timestamp)', name: 'reminder', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Relationship Link ID',
+				name: 'relationshipLinkId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Relationship Link Type ID',
+				name: 'relationshipLinkTypeId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Reminder (Timestamp)',
+				name: 'reminder',
+				type: 'number' as const,
+				default: 0,
+			},
 			{ displayName: 'Remitter ID', name: 'remitterId', type: 'number' as const, default: 0 },
 			{ displayName: 'Repair', name: 'repair', type: 'boolean' as const, default: false },
-			{ displayName: 'Resubmission Date (Timestamp)', name: 'resubmissionDate', type: 'number' as const, default: 0 },
-			{ displayName: 'Resubmission Text', name: 'resubmissionText', type: 'string' as const, default: '' },
-			{ displayName: 'Separate Billing', name: 'separateBilling', type: 'boolean' as const, default: false },
-			{ displayName: 'Service Cap Amount', name: 'serviceCapAmount', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Resubmission Date (Timestamp)',
+				name: 'resubmissionDate',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Resubmission Text',
+				name: 'resubmissionText',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'Separate Billing',
+				name: 'separateBilling',
+				type: 'boolean' as const,
+				default: false,
+			},
+			{
+				displayName: 'Service Cap Amount',
+				name: 'serviceCapAmount',
+				type: 'number' as const,
+				default: 0,
+			},
 			{ displayName: 'Status ID', name: 'statusId', type: 'number' as const, default: 0 },
 			{
 				displayName: 'Sub Tickets',
@@ -274,7 +414,8 @@ export const ticketFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'json' as const,
 				default: '',
-				description: 'An array of objects with tag assignments which will be assigned to the ticket',
+				description:
+					'An array of objects with tag assignments which will be assigned to the ticket',
 			},
 			{ displayName: 'Title', name: 'title', type: 'string' as const, default: '' },
 			{ displayName: 'Type ID', name: 'typeId', type: 'number' as const, default: 0 },
@@ -309,8 +450,12 @@ export async function handleTicket(this: IExecuteFunctions, i: number) {
 		case 'createTicket': {
 			url = `${credentials.baseURL}/backend/api/v1/tickets`;
 			requestOptions.method = 'POST';
-			const createTicketFields = this.getNodeParameter('createTicketFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(createTicketFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields provided for ticket creation.');
+			const createTicketFields = this.getNodeParameter('createTicketFields', i, {}) as Record<
+				string,
+				unknown
+			>;
+			if (Object.keys(createTicketFields).length === 0)
+				throw new NodeOperationError(this.getNode(), 'No fields provided for ticket creation.');
 			requestOptions.body = createTicketFields;
 			break;
 		}
@@ -334,7 +479,8 @@ export async function handleTicket(this: IExecuteFunctions, i: number) {
 		case 'updateTicket': {
 			url = `${credentials.baseURL}/backend/api/v1/tickets/${ticketId}`;
 			const updateFields = this.getNodeParameter('updateFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(updateFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields to update were provided.');
+			if (Object.keys(updateFields).length === 0)
+				throw new NodeOperationError(this.getNode(), 'No fields to update were provided.');
 			requestOptions.method = 'PUT';
 			requestOptions.body = updateFields;
 			break;
@@ -353,13 +499,18 @@ export async function handleTicket(this: IExecuteFunctions, i: number) {
 			break;
 		}
 		default:
-			throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized.`);
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized.`,
+			);
 	}
 
 	requestOptions.url = url;
 
 	try {
-		const responseData = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
+		const responseData = await this.helpers.httpRequest(
+			requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+		);
 		return responseData;
 	} catch (error: unknown) {
 		const errorMessage = error instanceof Error ? error.message : String(error);

--- a/nodes/tanss/sub/calls.ts
+++ b/nodes/tanss/sub/calls.ts
@@ -1,916 +1,1176 @@
 import { IExecuteFunctions, INodeProperties, NodeOperationError, IDataObject } from 'n8n-workflow';
 
 export const callsOperations: INodeProperties[] = [
-    {
-        displayName: 'Operation',
-        name: 'operation',
-        type: 'options' as const,
-        noDataExpression: true,
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-            },
-        },
-        options: [
-            {
-                name: 'Create / Import Call',
-                value: 'createCall',
-                description: 'Creates/imports a phone call into the database',
-                action: 'Create call',
-            },
-            {
-                name: 'Get a List of Phone Calls',
-                value: 'getCalls',
-                description: 'Retrieves a list of phone calls using filter settings',
-                action: 'Get calls',
-            },
-            {
-                name: 'Get Phone Call By ID',
-                value: 'getCallById',
-                description: 'Gets a specific phone call by its ID',
-                action: 'Get call by id',
-            },
-            {
-                name: 'Update Phone Call',
-                value: 'updateCall',
-                description: 'Updates an existing phone call by ID',
-                action: 'Update call',
-            },
-            {
-                name: 'Identify Phone Call',
-                value: 'identifyCall',
-                description: 'Identifies a phone call and resolves company / employee IDs',
-                action: 'Identify call',
-            },
-            {
-                name: 'Get All Employee Assignments',
-                value: 'getEmployeeAssignments',
-                description: 'Get all assignments between idStrings and TANSS employees',
-                action: 'Get employee assignments',
-            },
-            {
-                name: 'Create Employee Assignment',
-                value: 'createEmployeeAssignment',
-                description: 'Creates a new assignment between an idString and a TANSS employee',
-                action: 'Create employee assignment',
-            },
-            {
-                name: 'Delete Employee Assignment',
-                value: 'deleteEmployeeAssignment',
-                description: 'Deletes an assignment between an idString and a TANSS employee',
-                action: 'Delete employee assignment',
-            },
-            {
-                name: 'Creates a Call Notification',
-                value: 'createNotification',
-                description: 'Generates a notification (popup) for an incoming or outgoing call',
-                action: 'Create call notification',
-            },
-        ],
-        default: 'createCall',
-    },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options' as const,
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+			},
+		},
+		options: [
+			{
+				name: 'Create / Import Call',
+				value: 'createCall',
+				description: 'Creates/imports a phone call into the database',
+				action: 'Create call',
+			},
+			{
+				name: 'Get a List of Phone Calls',
+				value: 'getCalls',
+				description: 'Retrieves a list of phone calls using filter settings',
+				action: 'Get calls',
+			},
+			{
+				name: 'Get Phone Call By ID',
+				value: 'getCallById',
+				description: 'Gets a specific phone call by its ID',
+				action: 'Get call by id',
+			},
+			{
+				name: 'Update Phone Call',
+				value: 'updateCall',
+				description: 'Updates an existing phone call by ID',
+				action: 'Update call',
+			},
+			{
+				name: 'Identify Phone Call',
+				value: 'identifyCall',
+				description: 'Identifies a phone call and resolves company / employee IDs',
+				action: 'Identify call',
+			},
+			{
+				name: 'Get All Employee Assignments',
+				value: 'getEmployeeAssignments',
+				description: 'Get all assignments between idStrings and TANSS employees',
+				action: 'Get employee assignments',
+			},
+			{
+				name: 'Create Employee Assignment',
+				value: 'createEmployeeAssignment',
+				description: 'Creates a new assignment between an idString and a TANSS employee',
+				action: 'Create employee assignment',
+			},
+			{
+				name: 'Delete Employee Assignment',
+				value: 'deleteEmployeeAssignment',
+				description: 'Deletes an assignment between an idString and a TANSS employee',
+				action: 'Delete employee assignment',
+			},
+			{
+				name: 'Creates a Call Notification',
+				value: 'createNotification',
+				description: 'Generates a notification (popup) for an incoming or outgoing call',
+				action: 'Create call notification',
+			},
+		],
+		default: 'createCall',
+	},
 ];
 
 export const callsFields: INodeProperties[] = [
-    {
-        displayName: 'API Token',
-        name: 'apiToken',
-        type: 'string' as const,
-        required: true,
-        typeOptions: { password: true },
-        default: '',
-        description: 'API token obtained from the TANSS web interface (must be generated in TANSS)',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-            },
-        },
-    },
-    {
-        displayName: 'Use Raw Call JSON (Optional)',
-        name: 'callJson',
-        type: 'string' as const,
-        default: '',
-        description: 'If provided (valid JSON), this object will be posted as-is. Otherwise the fields below / collection are used to build the payload.',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['createCall', 'updateCall'],
-            },
-        },
-    },
+	{
+		displayName: 'API Token',
+		name: 'apiToken',
+		type: 'string' as const,
+		required: true,
+		typeOptions: { password: true },
+		default: '',
+		description: 'API token obtained from the TANSS web interface (must be generated in TANSS)',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+			},
+		},
+	},
+	{
+		displayName: 'Use Raw Call JSON (Optional)',
+		name: 'callJson',
+		type: 'string' as const,
+		default: '',
+		description:
+			'If provided (valid JSON), this object will be posted as-is. Otherwise the fields below / collection are used to build the payload.',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['createCall', 'updateCall'],
+			},
+		},
+	},
 
-    {
-        displayName: 'Use Raw Notification JSON (Optional)',
-        name: 'notificationJson',
-        type: 'string' as const,
-        default: '',
-        description: 'If provided (valid JSON), this object will be posted as-is',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['createNotification'],
-            },
-        },
-    },
-    {
-        displayName: 'Notification Fields',
-        name: 'notificationFields',
-        type: 'collection' as const,
-        placeholder: 'Add Field',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['createNotification'],
-            },
-        },
-        default: {},
-        options: [
-            { displayName: 'ID', name: 'id', type: 'number' as const, default: 0 },
-            { displayName: 'callId', name: 'callId', type: 'string' as const, default: '' },
-            { displayName: 'telephoneSystemId', name: 'telephoneSystemId', type: 'number' as const, default: 0 },
-            { displayName: 'Date (Timestamp)', name: 'date', type: 'number' as const, default: 0 },
-            { displayName: 'From Phone Number', name: 'fromPhoneNumber', type: 'string' as const, default: '' },
-            { displayName: 'fromPhoneNrInfos (JSON)', name: 'fromPhoneNrInfos', type: 'string' as const, default: '', description: 'Optional JSON object' },
-            { displayName: 'To Phone Number', name: 'toPhoneNumber', type: 'string' as const, default: '' },
-            { displayName: 'toPhoneNrInfos (JSON)', name: 'toPhoneNrInfos', type: 'string' as const, default: '', description: 'Optional JSON object' },
-            {
-                displayName: 'Direction',
-                name: 'direction',
-                type: 'options' as const,
-                options: [
-                    { name: 'INTERNAL', value: 'INTERNAL' },
-                    { name: 'INCOMING', value: 'INCOMING' },
-                    { name: 'OUTGOING', value: 'OUTGOING' },
-                ],
-                default: 'INTERNAL',
-            },
-            { displayName: 'connectionEstablished', name: 'connectionEstablished', type: 'boolean' as const, default: false },
-            { displayName: 'durationTotal (Seconds)', name: 'durationTotal', type: 'number' as const, default: 0 },
-            { displayName: 'durationCall (Seconds)', name: 'durationCall', type: 'number' as const, default: 0 },
-            { displayName: 'Group', name: 'group', type: 'string' as const, default: '' },
-            {
-                displayName: 'Phone Participants JSON',
-                name: 'phoneParticipantsJson',
-                type: 'string' as const,
-                default: '',
-                description: 'JSON array of phone participant objects. If provided, this will be used.',
-            },
-            {
-                displayName: 'Phone Participants (Collection)',
-                name: 'phoneParticipants',
-                type: 'fixedCollection' as const,
-                placeholder: 'Add participant',
-                typeOptions: { multipleValues: true },
-                default: {},
-                options: [
-                    {
-                        displayName: 'Participant',
-                        name: 'participant',
-                        values: [
-                            { displayName: 'phoneCallId', name: 'phoneCallId', type: 'number' as const, default: 0 },
-                            { displayName: 'idString', name: 'idString', type: 'string' as const, default: '' },
-                            { displayName: 'employeeId', name: 'employeeId', type: 'number' as const, default: 0 },
-                        ],
-                    },
-                ],
-            },
-        ],
-    },
+	{
+		displayName: 'Use Raw Notification JSON (Optional)',
+		name: 'notificationJson',
+		type: 'string' as const,
+		default: '',
+		description: 'If provided (valid JSON), this object will be posted as-is',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['createNotification'],
+			},
+		},
+	},
+	{
+		displayName: 'Notification Fields',
+		name: 'notificationFields',
+		type: 'collection' as const,
+		placeholder: 'Add Field',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['createNotification'],
+			},
+		},
+		default: {},
+		options: [
+			{ displayName: 'ID', name: 'id', type: 'number' as const, default: 0 },
+			{ displayName: 'callId', name: 'callId', type: 'string' as const, default: '' },
+			{
+				displayName: 'telephoneSystemId',
+				name: 'telephoneSystemId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{ displayName: 'Date (Timestamp)', name: 'date', type: 'number' as const, default: 0 },
+			{
+				displayName: 'From Phone Number',
+				name: 'fromPhoneNumber',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'fromPhoneNrInfos (JSON)',
+				name: 'fromPhoneNrInfos',
+				type: 'string' as const,
+				default: '',
+				description: 'Optional JSON object',
+			},
+			{
+				displayName: 'To Phone Number',
+				name: 'toPhoneNumber',
+				type: 'string' as const,
+				default: '',
+			},
+			{
+				displayName: 'toPhoneNrInfos (JSON)',
+				name: 'toPhoneNrInfos',
+				type: 'string' as const,
+				default: '',
+				description: 'Optional JSON object',
+			},
+			{
+				displayName: 'Direction',
+				name: 'direction',
+				type: 'options' as const,
+				options: [
+					{ name: 'INTERNAL', value: 'INTERNAL' },
+					{ name: 'INCOMING', value: 'INCOMING' },
+					{ name: 'OUTGOING', value: 'OUTGOING' },
+				],
+				default: 'INTERNAL',
+			},
+			{
+				displayName: 'connectionEstablished',
+				name: 'connectionEstablished',
+				type: 'boolean' as const,
+				default: false,
+			},
+			{
+				displayName: 'durationTotal (Seconds)',
+				name: 'durationTotal',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'durationCall (Seconds)',
+				name: 'durationCall',
+				type: 'number' as const,
+				default: 0,
+			},
+			{ displayName: 'Group', name: 'group', type: 'string' as const, default: '' },
+			{
+				displayName: 'Phone Participants JSON',
+				name: 'phoneParticipantsJson',
+				type: 'string' as const,
+				default: '',
+				description: 'JSON array of phone participant objects. If provided, this will be used.',
+			},
+			{
+				displayName: 'Phone Participants (Collection)',
+				name: 'phoneParticipants',
+				type: 'fixedCollection' as const,
+				placeholder: 'Add participant',
+				typeOptions: { multipleValues: true },
+				default: {},
+				options: [
+					{
+						displayName: 'Participant',
+						name: 'participant',
+						values: [
+							{
+								displayName: 'phoneCallId',
+								name: 'phoneCallId',
+								type: 'number' as const,
+								default: 0,
+							},
+							{ displayName: 'idString', name: 'idString', type: 'string' as const, default: '' },
+							{
+								displayName: 'employeeId',
+								name: 'employeeId',
+								type: 'number' as const,
+								default: 0,
+							},
+						],
+					},
+				],
+			},
+		],
+	},
 
-    {
-        displayName: 'Use Raw Filter JSON (Optional)',
-        name: 'filterJson',
-        type: 'string' as const,
-        default: '',
-        description: 'If provided (valid JSON), this object will be sent as the request body for the list call',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['getCalls'],
-            },
-        },
-    },
+	{
+		displayName: 'Use Raw Filter JSON (Optional)',
+		name: 'filterJson',
+		type: 'string' as const,
+		default: '',
+		description:
+			'If provided (valid JSON), this object will be sent as the request body for the list call',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['getCalls'],
+			},
+		},
+	},
 
-    {
-        displayName: 'Filter Settings',
-        name: 'getCallsFilters',
-        type: 'collection' as const,
-        placeholder: 'Add Filter',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['getCalls'],
-            },
-        },
-        default: {},
-        options: [
-            {
-                displayName: 'Timeframe From (Timestamp)',
-                name: 'timeFrom',
-                type: 'number' as const,
-                default: 0,
-                description: 'Unix timestamp of the "from" date',
-            },
-            {
-                displayName: 'Timeframe To (Timestamp)',
-                name: 'timeTo',
-                type: 'number' as const,
-                default: 0,
-                description: 'Unix timestamp of the "to" date',
-            },
-            {
-                displayName: 'Show Tries As Well',
-                name: 'showTrysAsWell',
-                type: 'boolean' as const,
-                default: false,
-                description: 'If true, include calls without established connection',
-            },
-            {
-                displayName: 'Number Filters (Comma Separated)',
-                name: 'numberFilters',
-                type: 'string' as const,
-                default: '',
-                description: 'One or more telephone number filters, comma-separated',
-            },
-            {
-                displayName: 'Employee ID',
-                name: 'employeeIdFilter',
-                type: 'number' as const,
-                default: 0,
-                description: 'Only show phone calls of this employee',
-            },
-            {
-                displayName: 'Company ID',
-                name: 'companyIdFilter',
-                type: 'number' as const,
-                default: 0,
-                description: 'Only show phone calls of this company',
-            },
-            {
-                displayName: 'Number Infos',
-                name: 'numberInfos',
-                type: 'boolean' as const,
-                default: false,
-                description: 'If true, fromPhoneNrInfos and toPhoneNrInfos will be determined',
-            },
-            {
-                displayName: 'Directions',
-                name: 'directions',
-                type: 'multiOptions' as const,
-                options: [
-                    { name: 'INTERNAL', value: 'INTERNAL' },
-                    { name: 'INCOMING', value: 'INCOMING' },
-                    { name: 'OUTGOING', value: 'OUTGOING' },
-                ],
-                default: [],
-                description: 'Filter by call directions',
-            },
-        ],
-    },
+	{
+		displayName: 'Filter Settings',
+		name: 'getCallsFilters',
+		type: 'collection' as const,
+		placeholder: 'Add Filter',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['getCalls'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'Timeframe From (Timestamp)',
+				name: 'timeFrom',
+				type: 'number' as const,
+				default: 0,
+				description: 'Unix timestamp of the "from" date',
+			},
+			{
+				displayName: 'Timeframe To (Timestamp)',
+				name: 'timeTo',
+				type: 'number' as const,
+				default: 0,
+				description: 'Unix timestamp of the "to" date',
+			},
+			{
+				displayName: 'Show Tries As Well',
+				name: 'showTrysAsWell',
+				type: 'boolean' as const,
+				default: false,
+				description: 'If true, include calls without established connection',
+			},
+			{
+				displayName: 'Number Filters (Comma Separated)',
+				name: 'numberFilters',
+				type: 'string' as const,
+				default: '',
+				description: 'One or more telephone number filters, comma-separated',
+			},
+			{
+				displayName: 'Employee ID',
+				name: 'employeeIdFilter',
+				type: 'number' as const,
+				default: 0,
+				description: 'Only show phone calls of this employee',
+			},
+			{
+				displayName: 'Company ID',
+				name: 'companyIdFilter',
+				type: 'number' as const,
+				default: 0,
+				description: 'Only show phone calls of this company',
+			},
+			{
+				displayName: 'Number Infos',
+				name: 'numberInfos',
+				type: 'boolean' as const,
+				default: false,
+				description: 'If true, fromPhoneNrInfos and toPhoneNrInfos will be determined',
+			},
+			{
+				displayName: 'Directions',
+				name: 'directions',
+				type: 'multiOptions' as const,
+				options: [
+					{ name: 'INTERNAL', value: 'INTERNAL' },
+					{ name: 'INCOMING', value: 'INCOMING' },
+					{ name: 'OUTGOING', value: 'OUTGOING' },
+				],
+				default: [],
+				description: 'Filter by call directions',
+			},
+		],
+	},
 
-    {
-        displayName: 'Phone Call ID',
-        name: 'phoneCallId',
-        type: 'number' as const,
-        default: 0,
-        description: 'ID of the phone call to fetch/update',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['getCallById', 'updateCall'],
-            },
-        },
-    },
-    {
-        displayName: 'Use Raw Identify JSON (Optional)',
-        name: 'identifyJson',
-        type: 'string' as const,
-        default: '',
-        description: 'If provided (valid JSON), this object will be posted as-is to identify endpoint',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['identifyCall'],
-            },
-        },
-    },
-    {
-        displayName: 'Identify Fields',
-        name: 'identifyFields',
-        type: 'collection' as const,
-        placeholder: 'Add Field',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['identifyCall'],
-            },
-        },
-        default: {},
-        options: [
-            { displayName: 'From Phone Number', name: 'fromPhoneNumber', type: 'string' as const, default: '', description: 'Phone number of the caller' },
-            { displayName: 'To Phone Number', name: 'toPhoneNumber', type: 'string' as const, default: '', description: 'Phone number of the called party' },
-        ],
-    },
+	{
+		displayName: 'Phone Call ID',
+		name: 'phoneCallId',
+		type: 'number' as const,
+		default: 0,
+		description: 'ID of the phone call to fetch/update',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['getCallById', 'updateCall'],
+			},
+		},
+	},
+	{
+		displayName: 'Use Raw Identify JSON (Optional)',
+		name: 'identifyJson',
+		type: 'string' as const,
+		default: '',
+		description: 'If provided (valid JSON), this object will be posted as-is to identify endpoint',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['identifyCall'],
+			},
+		},
+	},
+	{
+		displayName: 'Identify Fields',
+		name: 'identifyFields',
+		type: 'collection' as const,
+		placeholder: 'Add Field',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['identifyCall'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'From Phone Number',
+				name: 'fromPhoneNumber',
+				type: 'string' as const,
+				default: '',
+				description: 'Phone number of the caller',
+			},
+			{
+				displayName: 'To Phone Number',
+				name: 'toPhoneNumber',
+				type: 'string' as const,
+				default: '',
+				description: 'Phone number of the called party',
+			},
+		],
+	},
 
-    {
-        displayName: 'Use Raw Employee Assignment JSON (Optional)',
-        name: 'employeeAssignmentJson',
-        type: 'string' as const,
-        default: '',
-        description: 'If provided (valid JSON), this object will be posted as-is to employeeAssignment endpoints',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['createEmployeeAssignment', 'deleteEmployeeAssignment'],
-            },
-        },
-    },
-    {
-        displayName: 'Employee Assignment Fields',
-        name: 'employeeAssignmentFields',
-        type: 'collection' as const,
-        placeholder: 'Add Field',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['createEmployeeAssignment', 'deleteEmployeeAssignment'],
-            },
-        },
-        default: {},
-        options: [
-            { displayName: 'Employee ID', name: 'employeeId', type: 'number' as const, default: 0, description: 'ID of the TANSS employee' },
-            { displayName: 'Username / idString', name: 'username', type: 'string' as const, default: '', description: 'Identifier string of the employee (idString)' },
-        ],
-    },
-    {
-        displayName: 'Create Call Fields',
-        name: 'createCallFields',
-        type: 'collection' as const,
-        placeholder: 'Add Field',
-        displayOptions: {
-            show: {
-                resource: ['calls'],
-                operation: ['createCall', 'updateCall'],
-            },
-        },
-        default: {},
-        options: [
-            { displayName: 'Date (Timestamp)', name: 'date', type: 'number' as const, default: 0, description: 'Unix timestamp representing the begin of the phone call' },
-            { displayName: 'fromPhoneNumber', name: 'fromPhoneNumber', type: 'string' as const, default: '', description: 'Phone number (or identifier) of the caller' },
-            { displayName: 'toPhoneNumber', name: 'toPhoneNumber', type: 'string' as const, default: '', description: 'Phone number (or identifier) of the called party' },
-            {
-                displayName: 'Direction',
-                name: 'direction',
-                type: 'options' as const,
-                options: [
-                    { name: 'INTERNAL', value: 'INTERNAL' },
-                    { name: 'INCOMING', value: 'INCOMING' },
-                    { name: 'OUTGOING', value: 'OUTGOING' },
-                ],
-                default: 'INTERNAL',
-                description: 'Defines the direction of the call',
-            },
-            { displayName: 'callId', name: 'callId', type: 'string' as const, default: '', description: 'External ID of the phone call' },
-            { displayName: 'telephoneSystemId', name: 'telephoneSystemId', type: 'number' as const, default: 0 },
-            { displayName: 'fromCompanyId', name: 'fromCompanyId', type: 'number' as const, default: 0 },
-            { displayName: 'fromCompanyPercent', name: 'fromCompanyPercent', type: 'number' as const, default: 0 },
-            { displayName: 'fromEmployeeId', name: 'fromEmployeeId', type: 'number' as const, default: 0 },
-            { displayName: 'toCompanyId', name: 'toCompanyId', type: 'number' as const, default: 0 },
-            { displayName: 'toCompanyPercent', name: 'toCompanyPercent', type: 'number' as const, default: 0 },
-            { displayName: 'toEmployeeId', name: 'toEmployeeId', type: 'number' as const, default: 0 },
-            { displayName: 'connectionEstablished', name: 'connectionEstablished', type: 'boolean' as const, default: false },
-            { displayName: 'durationTotal (Seconds)', name: 'durationTotal', type: 'number' as const, default: 0 },
-            { displayName: 'durationCall (Seconds)', name: 'durationCall', type: 'number' as const, default: 0 },
-            { displayName: 'Group', name: 'group', type: 'string' as const, default: '' },
-            { displayName: 'numberIdentifyState', name: 'numberIdentifyState', type: 'string' as const, default: '' },
+	{
+		displayName: 'Use Raw Employee Assignment JSON (Optional)',
+		name: 'employeeAssignmentJson',
+		type: 'string' as const,
+		default: '',
+		description:
+			'If provided (valid JSON), this object will be posted as-is to employeeAssignment endpoints',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['createEmployeeAssignment', 'deleteEmployeeAssignment'],
+			},
+		},
+	},
+	{
+		displayName: 'Employee Assignment Fields',
+		name: 'employeeAssignmentFields',
+		type: 'collection' as const,
+		placeholder: 'Add Field',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['createEmployeeAssignment', 'deleteEmployeeAssignment'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'Employee ID',
+				name: 'employeeId',
+				type: 'number' as const,
+				default: 0,
+				description: 'ID of the TANSS employee',
+			},
+			{
+				displayName: 'Username / idString',
+				name: 'username',
+				type: 'string' as const,
+				default: '',
+				description: 'Identifier string of the employee (idString)',
+			},
+		],
+	},
+	{
+		displayName: 'Create Call Fields',
+		name: 'createCallFields',
+		type: 'collection' as const,
+		placeholder: 'Add Field',
+		displayOptions: {
+			show: {
+				resource: ['calls'],
+				operation: ['createCall', 'updateCall'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'Date (Timestamp)',
+				name: 'date',
+				type: 'number' as const,
+				default: 0,
+				description: 'Unix timestamp representing the begin of the phone call',
+			},
+			{
+				displayName: 'fromPhoneNumber',
+				name: 'fromPhoneNumber',
+				type: 'string' as const,
+				default: '',
+				description: 'Phone number (or identifier) of the caller',
+			},
+			{
+				displayName: 'toPhoneNumber',
+				name: 'toPhoneNumber',
+				type: 'string' as const,
+				default: '',
+				description: 'Phone number (or identifier) of the called party',
+			},
+			{
+				displayName: 'Direction',
+				name: 'direction',
+				type: 'options' as const,
+				options: [
+					{ name: 'INTERNAL', value: 'INTERNAL' },
+					{ name: 'INCOMING', value: 'INCOMING' },
+					{ name: 'OUTGOING', value: 'OUTGOING' },
+				],
+				default: 'INTERNAL',
+				description: 'Defines the direction of the call',
+			},
+			{
+				displayName: 'callId',
+				name: 'callId',
+				type: 'string' as const,
+				default: '',
+				description: 'External ID of the phone call',
+			},
+			{
+				displayName: 'telephoneSystemId',
+				name: 'telephoneSystemId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{ displayName: 'fromCompanyId', name: 'fromCompanyId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'fromCompanyPercent',
+				name: 'fromCompanyPercent',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'fromEmployeeId',
+				name: 'fromEmployeeId',
+				type: 'number' as const,
+				default: 0,
+			},
+			{ displayName: 'toCompanyId', name: 'toCompanyId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'toCompanyPercent',
+				name: 'toCompanyPercent',
+				type: 'number' as const,
+				default: 0,
+			},
+			{ displayName: 'toEmployeeId', name: 'toEmployeeId', type: 'number' as const, default: 0 },
+			{
+				displayName: 'connectionEstablished',
+				name: 'connectionEstablished',
+				type: 'boolean' as const,
+				default: false,
+			},
+			{
+				displayName: 'durationTotal (Seconds)',
+				name: 'durationTotal',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'durationCall (Seconds)',
+				name: 'durationCall',
+				type: 'number' as const,
+				default: 0,
+			},
+			{ displayName: 'Group', name: 'group', type: 'string' as const, default: '' },
+			{
+				displayName: 'numberIdentifyState',
+				name: 'numberIdentifyState',
+				type: 'string' as const,
+				default: '',
+			},
 
-            {
-                displayName: 'Phone Participants JSON',
-                name: 'phoneParticipantsJson',
-                type: 'string' as const,
-                default: '',
-                description: 'JSON array of phone participant objects. If provided, this will be used.',
-            },
-            {
-                displayName: 'Phone Participants (Collection)',
-                name: 'phoneParticipants',
-                type: 'fixedCollection' as const,
-                placeholder: 'Add participant',
-                typeOptions: { multipleValues: true },
-                default: {},
-                options: [
-                    {
-                        displayName: 'Participant',
-                        name: 'participant',
-                        values: [
-                            { displayName: 'idString', name: 'idString', type: 'string' as const, default: '' },
-                            { displayName: 'employeeId', name: 'employeeId', type: 'number' as const, default: 0 },
-                        ],
-                    },
-                ],
-            },
-        ],
-    },
+			{
+				displayName: 'Phone Participants JSON',
+				name: 'phoneParticipantsJson',
+				type: 'string' as const,
+				default: '',
+				description: 'JSON array of phone participant objects. If provided, this will be used.',
+			},
+			{
+				displayName: 'Phone Participants (Collection)',
+				name: 'phoneParticipants',
+				type: 'fixedCollection' as const,
+				placeholder: 'Add participant',
+				typeOptions: { multipleValues: true },
+				default: {},
+				options: [
+					{
+						displayName: 'Participant',
+						name: 'participant',
+						values: [
+							{ displayName: 'idString', name: 'idString', type: 'string' as const, default: '' },
+							{
+								displayName: 'employeeId',
+								name: 'employeeId',
+								type: 'number' as const,
+								default: 0,
+							},
+						],
+					},
+				],
+			},
+		],
+	},
 ];
 
 export async function handleCalls(this: IExecuteFunctions, i: number) {
-    const operation = this.getNodeParameter('operation', i) as string;
+	const operation = this.getNodeParameter('operation', i) as string;
 
-    const credentials = await this.getCredentials('tanssApi');
-    if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
-    const apiToken = this.getNodeParameter('apiToken', i, '') as string;
-    const typedCredentials = credentials as { baseURL?: string };
-    const baseURL = typedCredentials.baseURL;
-    if (!baseURL) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
+	const credentials = await this.getCredentials('tanssApi');
+	if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
+	const apiToken = this.getNodeParameter('apiToken', i, '') as string;
+	const typedCredentials = credentials as { baseURL?: string };
+	const baseURL = typedCredentials.baseURL;
+	if (!baseURL) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
 
-    if (operation === 'createCall') {
-        const callJson = this.getNodeParameter('callJson', i, '') as string;
+	if (operation === 'createCall') {
+		const callJson = this.getNodeParameter('callJson', i, '') as string;
 
-        let body: IDataObject = {};
+		let body: IDataObject = {};
 
-        // Priority: callJson (raw) > createCallFields collection > individual fields
-        if (callJson && callJson.trim() !== '') {
-            try {
-                const parsed = JSON.parse(callJson);
-                if (typeof parsed !== 'object' || parsed === null) {
-                    throw new Error('callJson must be an object');
-                }
-                body = parsed as IDataObject;
-            } catch {
-                throw new NodeOperationError(this.getNode(), 'callJson must be valid JSON object.');
-            }
-        } else {
-            const createCallFields = this.getNodeParameter('createCallFields', i, {}) as IDataObject;
-            if (createCallFields && Object.keys(createCallFields).length > 0) {
-                Object.assign(body, createCallFields);
+		// Priority: callJson (raw) > createCallFields collection > individual fields
+		if (callJson && callJson.trim() !== '') {
+			try {
+				const parsed = JSON.parse(callJson);
+				if (typeof parsed !== 'object' || parsed === null) {
+					throw new Error('callJson must be an object');
+				}
+				body = parsed as IDataObject;
+			} catch {
+				throw new NodeOperationError(this.getNode(), 'callJson must be valid JSON object.');
+			}
+		} else {
+			const createCallFields = this.getNodeParameter('createCallFields', i, {}) as IDataObject;
+			if (createCallFields && Object.keys(createCallFields).length > 0) {
+				Object.assign(body, createCallFields);
 
-                if (createCallFields.phoneParticipants && typeof createCallFields.phoneParticipants === 'object' && 'participant' in (createCallFields.phoneParticipants as Record<string, unknown>)) {
-                    const parts = ((createCallFields.phoneParticipants as Record<string, unknown>).participant as unknown) as Array<{ idString?: string; employeeId?: number }>;
-                    const list = parts.map((p) => {
-                        const obj: IDataObject = {};
-                        if (p.idString) obj.idString = p.idString;
-                        if (p.employeeId && p.employeeId > 0) obj.employeeId = p.employeeId;
-                        return obj;
-                    });
-                    body.phoneParticipants = list;
-                }
+				if (
+					createCallFields.phoneParticipants &&
+					typeof createCallFields.phoneParticipants === 'object' &&
+					'participant' in (createCallFields.phoneParticipants as Record<string, unknown>)
+				) {
+					const parts = (createCallFields.phoneParticipants as Record<string, unknown>)
+						.participant as unknown as Array<{ idString?: string; employeeId?: number }>;
+					const list = parts.map((p) => {
+						const obj: IDataObject = {};
+						if (p.idString) obj.idString = p.idString;
+						if (p.employeeId && p.employeeId > 0) obj.employeeId = p.employeeId;
+						return obj;
+					});
+					body.phoneParticipants = list;
+				}
 
-                if (createCallFields.phoneParticipantsJson && typeof createCallFields.phoneParticipantsJson === 'string' && createCallFields.phoneParticipantsJson.trim() !== '') {
-                    try {
-                        const parsed = JSON.parse(createCallFields.phoneParticipantsJson as string);
-                        if (Array.isArray(parsed)) body.phoneParticipants = parsed;
-                    } catch {
-                        throw new NodeOperationError(this.getNode(), 'createCallFields.phoneParticipantsJson must be valid JSON array.');
-                    }
-                }
-            } else {
-                const optionalString = (name: string) => {
-                    const v = this.getNodeParameter(name, i, '') as string;
-                    return v === '' ? undefined : v;
-                };
-                const optionalNumber = (name: string) => {
-                    const v = this.getNodeParameter(name, i, 0) as number;
-                    return v === 0 ? undefined : v;
-                };
-                const optionalBoolean = (name: string) => {
-                    return this.getNodeParameter(name, i, false) as boolean;
-                };
+				if (
+					createCallFields.phoneParticipantsJson &&
+					typeof createCallFields.phoneParticipantsJson === 'string' &&
+					createCallFields.phoneParticipantsJson.trim() !== ''
+				) {
+					try {
+						const parsed = JSON.parse(createCallFields.phoneParticipantsJson as string);
+						if (Array.isArray(parsed)) body.phoneParticipants = parsed;
+					} catch {
+						throw new NodeOperationError(
+							this.getNode(),
+							'createCallFields.phoneParticipantsJson must be valid JSON array.',
+						);
+					}
+				}
+			} else {
+				const optionalString = (name: string) => {
+					const v = this.getNodeParameter(name, i, '') as string;
+					return v === '' ? undefined : v;
+				};
+				const optionalNumber = (name: string) => {
+					const v = this.getNodeParameter(name, i, 0) as number;
+					return v === 0 ? undefined : v;
+				};
+				const optionalBoolean = (name: string) => {
+					return this.getNodeParameter(name, i, false) as boolean;
+				};
 
-                const callId = optionalString('callId');
-                const telephoneSystemId = optionalNumber('telephoneSystemId');
-                const date = optionalNumber('date');
-                const fromPhoneNumber = optionalString('fromPhoneNumber');
-                const fromCompanyId = optionalNumber('fromCompanyId');
-                const fromCompanyPercent = optionalNumber('fromCompanyPercent');
-                const fromEmployeeId = optionalNumber('fromEmployeeId');
-                const toPhoneNumber = optionalString('toPhoneNumber');
-                const toCompanyId = optionalNumber('toCompanyId');
-                const toCompanyPercent = optionalNumber('toCompanyPercent');
-                const toEmployeeId = optionalNumber('toEmployeeId');
-                const direction = this.getNodeParameter('direction', i, '') as string;
-                const connectionEstablished = optionalBoolean('connectionEstablished');
-                const durationTotal = optionalNumber('durationTotal');
-                const durationCall = optionalNumber('durationCall');
-                const group = optionalString('group');
-                const numberIdentifyState = optionalString('numberIdentifyState');
+				const callId = optionalString('callId');
+				const telephoneSystemId = optionalNumber('telephoneSystemId');
+				const date = optionalNumber('date');
+				const fromPhoneNumber = optionalString('fromPhoneNumber');
+				const fromCompanyId = optionalNumber('fromCompanyId');
+				const fromCompanyPercent = optionalNumber('fromCompanyPercent');
+				const fromEmployeeId = optionalNumber('fromEmployeeId');
+				const toPhoneNumber = optionalString('toPhoneNumber');
+				const toCompanyId = optionalNumber('toCompanyId');
+				const toCompanyPercent = optionalNumber('toCompanyPercent');
+				const toEmployeeId = optionalNumber('toEmployeeId');
+				const direction = this.getNodeParameter('direction', i, '') as string;
+				const connectionEstablished = optionalBoolean('connectionEstablished');
+				const durationTotal = optionalNumber('durationTotal');
+				const durationCall = optionalNumber('durationCall');
+				const group = optionalString('group');
+				const numberIdentifyState = optionalString('numberIdentifyState');
 
-                if (callId !== undefined) body.callId = callId;
-                if (telephoneSystemId !== undefined) body.telephoneSystemId = telephoneSystemId;
-                if (date !== undefined) body.date = date;
-                if (fromPhoneNumber !== undefined) body.fromPhoneNumber = fromPhoneNumber;
-                if (fromCompanyId !== undefined) body.fromCompanyId = fromCompanyId;
-                if (fromCompanyPercent !== undefined) body.fromCompanyPercent = fromCompanyPercent;
-                if (fromEmployeeId !== undefined) body.fromEmployeeId = fromEmployeeId;
-                if (toPhoneNumber !== undefined) body.toPhoneNumber = toPhoneNumber;
-                if (toCompanyId !== undefined) body.toCompanyId = toCompanyId;
-                if (toCompanyPercent !== undefined) body.toCompanyPercent = toCompanyPercent;
-                if (toEmployeeId !== undefined) body.toEmployeeId = toEmployeeId;
-                if (direction) body.direction = direction;
-                body.connectionEstablished = connectionEstablished;
-                if (durationTotal !== undefined) body.durationTotal = durationTotal;
-                if (durationCall !== undefined) body.durationCall = durationCall;
-                if (group !== undefined) body.group = group;
-                if (numberIdentifyState !== undefined) body.numberIdentifyState = numberIdentifyState;
+				if (callId !== undefined) body.callId = callId;
+				if (telephoneSystemId !== undefined) body.telephoneSystemId = telephoneSystemId;
+				if (date !== undefined) body.date = date;
+				if (fromPhoneNumber !== undefined) body.fromPhoneNumber = fromPhoneNumber;
+				if (fromCompanyId !== undefined) body.fromCompanyId = fromCompanyId;
+				if (fromCompanyPercent !== undefined) body.fromCompanyPercent = fromCompanyPercent;
+				if (fromEmployeeId !== undefined) body.fromEmployeeId = fromEmployeeId;
+				if (toPhoneNumber !== undefined) body.toPhoneNumber = toPhoneNumber;
+				if (toCompanyId !== undefined) body.toCompanyId = toCompanyId;
+				if (toCompanyPercent !== undefined) body.toCompanyPercent = toCompanyPercent;
+				if (toEmployeeId !== undefined) body.toEmployeeId = toEmployeeId;
+				if (direction) body.direction = direction;
+				body.connectionEstablished = connectionEstablished;
+				if (durationTotal !== undefined) body.durationTotal = durationTotal;
+				if (durationCall !== undefined) body.durationCall = durationCall;
+				if (group !== undefined) body.group = group;
+				if (numberIdentifyState !== undefined) body.numberIdentifyState = numberIdentifyState;
 
-                const participantsJson = this.getNodeParameter('phoneParticipantsJson', i, '') as string;
-                if (participantsJson && participantsJson.trim() !== '') {
-                    try {
-                        const parsed = JSON.parse(participantsJson);
-                        if (!Array.isArray(parsed)) throw new Error('phoneParticipantsJson must be an array');
-                        body.phoneParticipants = parsed;
-                    } catch {
-                        throw new NodeOperationError(this.getNode(), 'phoneParticipantsJson must be valid JSON array.');
-                    }
-                } else {
-                    const parts = this.getNodeParameter('phoneParticipants', i, { participant: [] }) as { participant?: Array<{ idString?: string; employeeId?: number }> };
-                    const list = (parts.participant ?? []).map(p => {
-                        const obj: IDataObject = {};
-                        if (p.idString) obj.idString = p.idString;
-                        if (p.employeeId && p.employeeId > 0) obj.employeeId = p.employeeId;
-                        return obj;
-                    }).filter(Boolean);
-                    if (list.length) body.phoneParticipants = list;
-                }
-            }
-        }
+				const participantsJson = this.getNodeParameter('phoneParticipantsJson', i, '') as string;
+				if (participantsJson && participantsJson.trim() !== '') {
+					try {
+						const parsed = JSON.parse(participantsJson);
+						if (!Array.isArray(parsed)) throw new Error('phoneParticipantsJson must be an array');
+						body.phoneParticipants = parsed;
+					} catch {
+						throw new NodeOperationError(
+							this.getNode(),
+							'phoneParticipantsJson must be valid JSON array.',
+						);
+					}
+				} else {
+					const parts = this.getNodeParameter('phoneParticipants', i, { participant: [] }) as {
+						participant?: Array<{ idString?: string; employeeId?: number }>;
+					};
+					const list = (parts.participant ?? [])
+						.map((p) => {
+							const obj: IDataObject = {};
+							if (p.idString) obj.idString = p.idString;
+							if (p.employeeId && p.employeeId > 0) obj.employeeId = p.employeeId;
+							return obj;
+						})
+						.filter(Boolean);
+					if (list.length) body.phoneParticipants = list;
+				}
+			}
+		}
 
-        const url = `${baseURL}/backend/api/calls/v1`;
-        const requestOptions: IDataObject = {
-            method: 'POST',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            body,
-            json: true,
-        };
+		const url = `${baseURL}/backend/api/calls/v1`;
+		const requestOptions: IDataObject = {
+			method: 'POST',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to create/import call: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to create/import call: ${message}`);
+		}
+	}
 
-    if (operation === 'getCalls') {
-        const filterJson = this.getNodeParameter('filterJson', i, '') as string;
-        let body: IDataObject = {};
+	if (operation === 'getCalls') {
+		const filterJson = this.getNodeParameter('filterJson', i, '') as string;
+		let body: IDataObject = {};
 
-        if (filterJson && filterJson.trim() !== '') {
-            try {
-                const parsed = JSON.parse(filterJson);
-                if (typeof parsed !== 'object' || parsed === null) {
-                    throw new Error('filterJson must be an object');
-                }
-                body = parsed as IDataObject;
-            } catch {
-                throw new NodeOperationError(this.getNode(), 'filterJson must be valid JSON object.');
-            }
-        } else {
-            const filters = this.getNodeParameter('getCallsFilters', i, {}) as IDataObject;
+		if (filterJson && filterJson.trim() !== '') {
+			try {
+				const parsed = JSON.parse(filterJson);
+				if (typeof parsed !== 'object' || parsed === null) {
+					throw new Error('filterJson must be an object');
+				}
+				body = parsed as IDataObject;
+			} catch {
+				throw new NodeOperationError(this.getNode(), 'filterJson must be valid JSON object.');
+			}
+		} else {
+			const filters = this.getNodeParameter('getCallsFilters', i, {}) as IDataObject;
 
-            const timeFrom = (filters.timeFrom as number) || 0;
-            const timeTo = (filters.timeTo as number) || 0;
-            if (timeFrom || timeTo) {
-                const timeframe: IDataObject = {};
-                if (timeFrom && timeFrom > 0) timeframe.from = timeFrom;
-                if (timeTo && timeTo > 0) timeframe.to = timeTo;
-                body.timeframe = timeframe;
-            }
+			const timeFrom = (filters.timeFrom as number) || 0;
+			const timeTo = (filters.timeTo as number) || 0;
+			if (timeFrom || timeTo) {
+				const timeframe: IDataObject = {};
+				if (timeFrom && timeFrom > 0) timeframe.from = timeFrom;
+				if (timeTo && timeTo > 0) timeframe.to = timeTo;
+				body.timeframe = timeframe;
+			}
 
-            if (filters.showTrysAsWell === true) body.showTrysAsWell = true;
+			if (filters.showTrysAsWell === true) body.showTrysAsWell = true;
 
-            if (filters.numberFilters && typeof filters.numberFilters === 'string' && (filters.numberFilters as string).trim() !== '') {
-                const arr = (filters.numberFilters as string).split(',').map(s => s.trim()).filter(Boolean);
-                if (arr.length) body.numberFilters = arr;
-            }
+			if (
+				filters.numberFilters &&
+				typeof filters.numberFilters === 'string' &&
+				(filters.numberFilters as string).trim() !== ''
+			) {
+				const arr = (filters.numberFilters as string)
+					.split(',')
+					.map((s) => s.trim())
+					.filter(Boolean);
+				if (arr.length) body.numberFilters = arr;
+			}
 
-            if (filters.employeeIdFilter && typeof filters.employeeIdFilter === 'number' && filters.employeeIdFilter > 0) body.employeeId = filters.employeeIdFilter;
-            if (filters.companyIdFilter && typeof filters.companyIdFilter === 'number' && filters.companyIdFilter > 0) body.companyId = filters.companyIdFilter;
-            if (filters.numberInfos === true) body.numberInfos = true;
+			if (
+				filters.employeeIdFilter &&
+				typeof filters.employeeIdFilter === 'number' &&
+				filters.employeeIdFilter > 0
+			)
+				body.employeeId = filters.employeeIdFilter;
+			if (
+				filters.companyIdFilter &&
+				typeof filters.companyIdFilter === 'number' &&
+				filters.companyIdFilter > 0
+			)
+				body.companyId = filters.companyIdFilter;
+			if (filters.numberInfos === true) body.numberInfos = true;
 
-            if (filters.directions && Array.isArray(filters.directions) && (filters.directions as string[]).length) {
-                body.directions = filters.directions;
-            }
-        }
+			if (
+				filters.directions &&
+				Array.isArray(filters.directions) &&
+				(filters.directions as string[]).length
+			) {
+				body.directions = filters.directions;
+			}
+		}
 
-        const url = `${baseURL}/backend/api/calls/v1`;
-        const requestOptions: IDataObject = {
-            method: 'PUT',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            body,
-            json: true,
-        };
+		const url = `${baseURL}/backend/api/calls/v1`;
+		const requestOptions: IDataObject = {
+			method: 'PUT',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to fetch calls list: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to fetch calls list: ${message}`);
+		}
+	}
 
-    if (operation === 'getCallById') {
-        const phoneCallId = this.getNodeParameter('phoneCallId', i, 0) as number;
-        if (!phoneCallId || phoneCallId <= 0) {
-            throw new NodeOperationError(this.getNode(), 'A valid Phone Call ID is required.');
-        }
+	if (operation === 'getCallById') {
+		const phoneCallId = this.getNodeParameter('phoneCallId', i, 0) as number;
+		if (!phoneCallId || phoneCallId <= 0) {
+			throw new NodeOperationError(this.getNode(), 'A valid Phone Call ID is required.');
+		}
 
-        const url = `${baseURL}/backend/api/calls/v1/${encodeURIComponent(String(phoneCallId))}`;
-        const requestOptions: IDataObject = {
-            method: 'GET',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            json: true,
-        };
+		const url = `${baseURL}/backend/api/calls/v1/${encodeURIComponent(String(phoneCallId))}`;
+		const requestOptions: IDataObject = {
+			method: 'GET',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to fetch phone call: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to fetch phone call: ${message}`);
+		}
+	}
 
-    if (operation === 'updateCall') {
-        const phoneCallId = this.getNodeParameter('phoneCallId', i, 0) as number;
-        if (!phoneCallId || phoneCallId <= 0) {
-            throw new NodeOperationError(this.getNode(), 'A valid Phone Call ID is required for update.');
-        }
+	if (operation === 'updateCall') {
+		const phoneCallId = this.getNodeParameter('phoneCallId', i, 0) as number;
+		if (!phoneCallId || phoneCallId <= 0) {
+			throw new NodeOperationError(this.getNode(), 'A valid Phone Call ID is required for update.');
+		}
 
-        const callJson = this.getNodeParameter('callJson', i, '') as string;
+		const callJson = this.getNodeParameter('callJson', i, '') as string;
 
-        let body: IDataObject = {};
+		let body: IDataObject = {};
 
-        if (callJson && callJson.trim() !== '') {
-            try {
-                const parsed = JSON.parse(callJson);
-                if (typeof parsed !== 'object' || parsed === null) {
-                    throw new Error('callJson must be an object');
-                }
-                body = parsed as IDataObject;
-            } catch {
-                throw new NodeOperationError(this.getNode(), 'callJson must be valid JSON object.');
-            }
-        } else {
-            const createCallFields = this.getNodeParameter('createCallFields', i, {}) as IDataObject;
-            if (createCallFields && Object.keys(createCallFields).length > 0) {
-                Object.assign(body, createCallFields);
+		if (callJson && callJson.trim() !== '') {
+			try {
+				const parsed = JSON.parse(callJson);
+				if (typeof parsed !== 'object' || parsed === null) {
+					throw new Error('callJson must be an object');
+				}
+				body = parsed as IDataObject;
+			} catch {
+				throw new NodeOperationError(this.getNode(), 'callJson must be valid JSON object.');
+			}
+		} else {
+			const createCallFields = this.getNodeParameter('createCallFields', i, {}) as IDataObject;
+			if (createCallFields && Object.keys(createCallFields).length > 0) {
+				Object.assign(body, createCallFields);
 
-                if (createCallFields.phoneParticipants && typeof createCallFields.phoneParticipants === 'object' && 'participant' in (createCallFields.phoneParticipants as Record<string, unknown>)) {
-                    const parts = ((createCallFields.phoneParticipants as Record<string, unknown>).participant as unknown) as Array<{ idString?: string; employeeId?: number }>;
-                    const list = parts.map((p) => {
-                        const obj: IDataObject = {};
-                        if (p.idString) obj.idString = p.idString;
-                        if (p.employeeId && p.employeeId > 0) obj.employeeId = p.employeeId;
-                        return obj;
-                    });
-                    body.phoneParticipants = list;
-                }
+				if (
+					createCallFields.phoneParticipants &&
+					typeof createCallFields.phoneParticipants === 'object' &&
+					'participant' in (createCallFields.phoneParticipants as Record<string, unknown>)
+				) {
+					const parts = (createCallFields.phoneParticipants as Record<string, unknown>)
+						.participant as unknown as Array<{ idString?: string; employeeId?: number }>;
+					const list = parts.map((p) => {
+						const obj: IDataObject = {};
+						if (p.idString) obj.idString = p.idString;
+						if (p.employeeId && p.employeeId > 0) obj.employeeId = p.employeeId;
+						return obj;
+					});
+					body.phoneParticipants = list;
+				}
 
-                if (createCallFields.phoneParticipantsJson && typeof createCallFields.phoneParticipantsJson === 'string' && createCallFields.phoneParticipantsJson.trim() !== '') {
-                    try {
-                        const parsed = JSON.parse(createCallFields.phoneParticipantsJson as string);
-                        if (Array.isArray(parsed)) body.phoneParticipants = parsed;
-                    } catch {
-                        throw new NodeOperationError(this.getNode(), 'createCallFields.phoneParticipantsJson must be valid JSON array.');
-                    }
-                }
-            } else {
-                const optionalString = (name: string) => {
-                    const v = this.getNodeParameter(name, i, '') as string;
-                    return v === '' ? undefined : v;
-                };
-                const optionalNumber = (name: string) => {
-                    const v = this.getNodeParameter(name, i, 0) as number;
-                    return v === 0 ? undefined : v;
-                };
-                const optionalBoolean = (name: string) => {
-                    return this.getNodeParameter(name, i, false) as boolean;
-                };
+				if (
+					createCallFields.phoneParticipantsJson &&
+					typeof createCallFields.phoneParticipantsJson === 'string' &&
+					createCallFields.phoneParticipantsJson.trim() !== ''
+				) {
+					try {
+						const parsed = JSON.parse(createCallFields.phoneParticipantsJson as string);
+						if (Array.isArray(parsed)) body.phoneParticipants = parsed;
+					} catch {
+						throw new NodeOperationError(
+							this.getNode(),
+							'createCallFields.phoneParticipantsJson must be valid JSON array.',
+						);
+					}
+				}
+			} else {
+				const optionalString = (name: string) => {
+					const v = this.getNodeParameter(name, i, '') as string;
+					return v === '' ? undefined : v;
+				};
+				const optionalNumber = (name: string) => {
+					const v = this.getNodeParameter(name, i, 0) as number;
+					return v === 0 ? undefined : v;
+				};
+				const optionalBoolean = (name: string) => {
+					return this.getNodeParameter(name, i, false) as boolean;
+				};
 
-                const callId = optionalString('callId');
-                const telephoneSystemId = optionalNumber('telephoneSystemId');
-                const date = optionalNumber('date');
-                const fromPhoneNumber = optionalString('fromPhoneNumber');
-                const fromCompanyId = optionalNumber('fromCompanyId');
-                const fromCompanyPercent = optionalNumber('fromCompanyPercent');
-                const fromEmployeeId = optionalNumber('fromEmployeeId');
-                const toPhoneNumber = optionalString('toPhoneNumber');
-                const toCompanyId = optionalNumber('toCompanyId');
-                const toCompanyPercent = optionalNumber('toCompanyPercent');
-                const toEmployeeId = optionalNumber('toEmployeeId');
-                const direction = this.getNodeParameter('direction', i, '') as string;
-                const connectionEstablished = optionalBoolean('connectionEstablished');
-                const durationTotal = optionalNumber('durationTotal');
-                const durationCall = optionalNumber('durationCall');
-                const group = optionalString('group');
-                const numberIdentifyState = optionalString('numberIdentifyState');
+				const callId = optionalString('callId');
+				const telephoneSystemId = optionalNumber('telephoneSystemId');
+				const date = optionalNumber('date');
+				const fromPhoneNumber = optionalString('fromPhoneNumber');
+				const fromCompanyId = optionalNumber('fromCompanyId');
+				const fromCompanyPercent = optionalNumber('fromCompanyPercent');
+				const fromEmployeeId = optionalNumber('fromEmployeeId');
+				const toPhoneNumber = optionalString('toPhoneNumber');
+				const toCompanyId = optionalNumber('toCompanyId');
+				const toCompanyPercent = optionalNumber('toCompanyPercent');
+				const toEmployeeId = optionalNumber('toEmployeeId');
+				const direction = this.getNodeParameter('direction', i, '') as string;
+				const connectionEstablished = optionalBoolean('connectionEstablished');
+				const durationTotal = optionalNumber('durationTotal');
+				const durationCall = optionalNumber('durationCall');
+				const group = optionalString('group');
+				const numberIdentifyState = optionalString('numberIdentifyState');
 
-                if (callId !== undefined) body.callId = callId;
-                if (telephoneSystemId !== undefined) body.telephoneSystemId = telephoneSystemId;
-                if (date !== undefined) body.date = date;
-                if (fromPhoneNumber !== undefined) body.fromPhoneNumber = fromPhoneNumber;
-                if (fromCompanyId !== undefined) body.fromCompanyId = fromCompanyId;
-                if (fromCompanyPercent !== undefined) body.fromCompanyPercent = fromCompanyPercent;
-                if (fromEmployeeId !== undefined) body.fromEmployeeId = fromEmployeeId;
-                if (toPhoneNumber !== undefined) body.toPhoneNumber = toPhoneNumber;
-                if (toCompanyId !== undefined) body.toCompanyId = toCompanyId;
-                if (toCompanyPercent !== undefined) body.toCompanyPercent = toCompanyPercent;
-                if (toEmployeeId !== undefined) body.toEmployeeId = toEmployeeId;
-                if (direction) body.direction = direction;
-                body.connectionEstablished = connectionEstablished;
-                if (durationTotal !== undefined) body.durationTotal = durationTotal;
-                if (durationCall !== undefined) body.durationCall = durationCall;
-                if (group !== undefined) body.group = group;
-                if (numberIdentifyState !== undefined) body.numberIdentifyState = numberIdentifyState;
+				if (callId !== undefined) body.callId = callId;
+				if (telephoneSystemId !== undefined) body.telephoneSystemId = telephoneSystemId;
+				if (date !== undefined) body.date = date;
+				if (fromPhoneNumber !== undefined) body.fromPhoneNumber = fromPhoneNumber;
+				if (fromCompanyId !== undefined) body.fromCompanyId = fromCompanyId;
+				if (fromCompanyPercent !== undefined) body.fromCompanyPercent = fromCompanyPercent;
+				if (fromEmployeeId !== undefined) body.fromEmployeeId = fromEmployeeId;
+				if (toPhoneNumber !== undefined) body.toPhoneNumber = toPhoneNumber;
+				if (toCompanyId !== undefined) body.toCompanyId = toCompanyId;
+				if (toCompanyPercent !== undefined) body.toCompanyPercent = toCompanyPercent;
+				if (toEmployeeId !== undefined) body.toEmployeeId = toEmployeeId;
+				if (direction) body.direction = direction;
+				body.connectionEstablished = connectionEstablished;
+				if (durationTotal !== undefined) body.durationTotal = durationTotal;
+				if (durationCall !== undefined) body.durationCall = durationCall;
+				if (group !== undefined) body.group = group;
+				if (numberIdentifyState !== undefined) body.numberIdentifyState = numberIdentifyState;
 
-                const participantsJson = this.getNodeParameter('phoneParticipantsJson', i, '') as string;
-                if (participantsJson && participantsJson.trim() !== '') {
-                    try {
-                        const parsed = JSON.parse(participantsJson);
-                        if (!Array.isArray(parsed)) throw new Error('phoneParticipantsJson must be an array');
-                        body.phoneParticipants = parsed;
-                    } catch {
-                        throw new NodeOperationError(this.getNode(), 'phoneParticipantsJson must be valid JSON array.');
-                    }
-                } else {
-                    const parts = this.getNodeParameter('phoneParticipants', i, { participant: [] }) as { participant?: Array<{ idString?: string; employeeId?: number }> };
-                    const list = (parts.participant ?? []).map(p => {
-                        const obj: IDataObject = {};
-                        if (p.idString) obj.idString = p.idString;
-                        if (p.employeeId && p.employeeId > 0) obj.employeeId = p.employeeId;
-                        return obj;
-                    }).filter(Boolean);
-                    if (list.length) body.phoneParticipants = list;
-                }
-            }
-        }
+				const participantsJson = this.getNodeParameter('phoneParticipantsJson', i, '') as string;
+				if (participantsJson && participantsJson.trim() !== '') {
+					try {
+						const parsed = JSON.parse(participantsJson);
+						if (!Array.isArray(parsed)) throw new Error('phoneParticipantsJson must be an array');
+						body.phoneParticipants = parsed;
+					} catch {
+						throw new NodeOperationError(
+							this.getNode(),
+							'phoneParticipantsJson must be valid JSON array.',
+						);
+					}
+				} else {
+					const parts = this.getNodeParameter('phoneParticipants', i, { participant: [] }) as {
+						participant?: Array<{ idString?: string; employeeId?: number }>;
+					};
+					const list = (parts.participant ?? [])
+						.map((p) => {
+							const obj: IDataObject = {};
+							if (p.idString) obj.idString = p.idString;
+							if (p.employeeId && p.employeeId > 0) obj.employeeId = p.employeeId;
+							return obj;
+						})
+						.filter(Boolean);
+					if (list.length) body.phoneParticipants = list;
+				}
+			}
+		}
 
-        const url = `${baseURL}/backend/api/calls/v1/${encodeURIComponent(String(phoneCallId))}`;
-        const requestOptions: IDataObject = {
-            method: 'PUT',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            body,
-            json: true,
-        };
+		const url = `${baseURL}/backend/api/calls/v1/${encodeURIComponent(String(phoneCallId))}`;
+		const requestOptions: IDataObject = {
+			method: 'PUT',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to update phone call: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to update phone call: ${message}`);
+		}
+	}
 
-    if (operation === 'identifyCall') {
-        const identifyJson = this.getNodeParameter('identifyJson', i, '') as string;
-        let body: IDataObject = {};
+	if (operation === 'identifyCall') {
+		const identifyJson = this.getNodeParameter('identifyJson', i, '') as string;
+		let body: IDataObject = {};
 
-        if (identifyJson && identifyJson.trim() !== '') {
-            try {
-                const parsed = JSON.parse(identifyJson);
-                if (typeof parsed !== 'object' || parsed === null) throw new Error('identifyJson must be an object');
-                body = parsed as IDataObject;
-            } catch {
-                throw new NodeOperationError(this.getNode(), 'identifyJson must be valid JSON object.');
-            }
-        } else {
-            const identifyFields = this.getNodeParameter('identifyFields', i, {}) as IDataObject;
-            const from = (identifyFields.fromPhoneNumber as string) || '';
-            const to = (identifyFields.toPhoneNumber as string) || '';
-            if (!from || !to) {
-                throw new NodeOperationError(this.getNode(), 'Both From Phone Number and To Phone Number are required to identify a call.');
-            }
-            body.fromPhoneNumber = from;
-            body.toPhoneNumber = to;
-        }
+		if (identifyJson && identifyJson.trim() !== '') {
+			try {
+				const parsed = JSON.parse(identifyJson);
+				if (typeof parsed !== 'object' || parsed === null)
+					throw new Error('identifyJson must be an object');
+				body = parsed as IDataObject;
+			} catch {
+				throw new NodeOperationError(this.getNode(), 'identifyJson must be valid JSON object.');
+			}
+		} else {
+			const identifyFields = this.getNodeParameter('identifyFields', i, {}) as IDataObject;
+			const from = (identifyFields.fromPhoneNumber as string) || '';
+			const to = (identifyFields.toPhoneNumber as string) || '';
+			if (!from || !to) {
+				throw new NodeOperationError(
+					this.getNode(),
+					'Both From Phone Number and To Phone Number are required to identify a call.',
+				);
+			}
+			body.fromPhoneNumber = from;
+			body.toPhoneNumber = to;
+		}
 
-        const url = `${baseURL}/backend/api/calls/v1/identify`;
-        const requestOptions: IDataObject = {
-            method: 'POST',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            body,
-            json: true,
-        };
+		const url = `${baseURL}/backend/api/calls/v1/identify`;
+		const requestOptions: IDataObject = {
+			method: 'POST',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to identify phone call: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to identify phone call: ${message}`);
+		}
+	}
 
-    if (operation === 'getEmployeeAssignments') {
-        const url = `${baseURL}/backend/api/calls/v1/employeeAssignment`;
-        const requestOptions: IDataObject = {
-            method: 'GET',
-            url,
-            headers: {
-                apiToken,
-                Authorization: `Bearer ${apiToken}`,
-                Accept: 'application/json',
-            },
-            json: true,
-        };
+	if (operation === 'getEmployeeAssignments') {
+		const url = `${baseURL}/backend/api/calls/v1/employeeAssignment`;
+		const requestOptions: IDataObject = {
+			method: 'GET',
+			url,
+			headers: {
+				apiToken,
+				Authorization: `Bearer ${apiToken}`,
+				Accept: 'application/json',
+			},
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to fetch employee assignments: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to fetch employee assignments: ${message}`,
+			);
+		}
+	}
 
-    if (operation === 'createEmployeeAssignment') {
-        const raw = this.getNodeParameter('employeeAssignmentJson', i, '') as string;
-        let body: IDataObject = {};
+	if (operation === 'createEmployeeAssignment') {
+		const raw = this.getNodeParameter('employeeAssignmentJson', i, '') as string;
+		let body: IDataObject = {};
 
-        if (raw && raw.trim() !== '') {
-            try {
-                const parsed = JSON.parse(raw);
-                if (typeof parsed !== 'object' || parsed === null) throw new Error('employeeAssignmentJson must be an object');
-                body = parsed as IDataObject;
-            } catch {
-                throw new NodeOperationError(this.getNode(), 'employeeAssignmentJson must be valid JSON object.');
-            }
-        } else {
-            const fields = this.getNodeParameter('employeeAssignmentFields', i, {}) as IDataObject;
-            const employeeId = (fields.employeeId as number) || 0;
-            const username = (fields.username as string) || '';
-            if (!employeeId || employeeId <= 0) throw new NodeOperationError(this.getNode(), 'Employee ID is required for creating assignment.');
-            if (!username) throw new NodeOperationError(this.getNode(), 'Username (idString) is required for creating assignment.');
-            body.employeeId = employeeId;
-            body.username = username;
-        }
+		if (raw && raw.trim() !== '') {
+			try {
+				const parsed = JSON.parse(raw);
+				if (typeof parsed !== 'object' || parsed === null)
+					throw new Error('employeeAssignmentJson must be an object');
+				body = parsed as IDataObject;
+			} catch {
+				throw new NodeOperationError(
+					this.getNode(),
+					'employeeAssignmentJson must be valid JSON object.',
+				);
+			}
+		} else {
+			const fields = this.getNodeParameter('employeeAssignmentFields', i, {}) as IDataObject;
+			const employeeId = (fields.employeeId as number) || 0;
+			const username = (fields.username as string) || '';
+			if (!employeeId || employeeId <= 0)
+				throw new NodeOperationError(
+					this.getNode(),
+					'Employee ID is required for creating assignment.',
+				);
+			if (!username)
+				throw new NodeOperationError(
+					this.getNode(),
+					'Username (idString) is required for creating assignment.',
+				);
+			body.employeeId = employeeId;
+			body.username = username;
+		}
 
-        const url = `${baseURL}/backend/api/calls/v1/employeeAssignment`;
-        const requestOptions: IDataObject = {
-            method: 'POST',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            body,
-            json: true,
-        };
+		const url = `${baseURL}/backend/api/calls/v1/employeeAssignment`;
+		const requestOptions: IDataObject = {
+			method: 'POST',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to create employee assignment: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to create employee assignment: ${message}`,
+			);
+		}
+	}
 
-    if (operation === 'deleteEmployeeAssignment') {
-        const raw = this.getNodeParameter('employeeAssignmentJson', i, '') as string;
-        let body: IDataObject = {};
+	if (operation === 'deleteEmployeeAssignment') {
+		const raw = this.getNodeParameter('employeeAssignmentJson', i, '') as string;
+		let body: IDataObject = {};
 
-        if (raw && raw.trim() !== '') {
-            try {
-                const parsed = JSON.parse(raw);
-                if (typeof parsed !== 'object' || parsed === null) throw new Error('employeeAssignmentJson must be an object');
-                body = parsed as IDataObject;
-            } catch {
-                throw new NodeOperationError(this.getNode(), 'employeeAssignmentJson must be valid JSON object.');
-            }
-        } else {
-            const fields = this.getNodeParameter('employeeAssignmentFields', i, {}) as IDataObject;
-            const employeeId = (fields.employeeId as number) || 0;
-            const username = (fields.username as string) || '';
-            if (!employeeId || employeeId <= 0) throw new NodeOperationError(this.getNode(), 'Employee ID is required for deleting assignment.');
-            if (!username) throw new NodeOperationError(this.getNode(), 'Username (idString) is required for deleting assignment.');
-            body.employeeId = employeeId;
-            body.username = username;
-        }
+		if (raw && raw.trim() !== '') {
+			try {
+				const parsed = JSON.parse(raw);
+				if (typeof parsed !== 'object' || parsed === null)
+					throw new Error('employeeAssignmentJson must be an object');
+				body = parsed as IDataObject;
+			} catch {
+				throw new NodeOperationError(
+					this.getNode(),
+					'employeeAssignmentJson must be valid JSON object.',
+				);
+			}
+		} else {
+			const fields = this.getNodeParameter('employeeAssignmentFields', i, {}) as IDataObject;
+			const employeeId = (fields.employeeId as number) || 0;
+			const username = (fields.username as string) || '';
+			if (!employeeId || employeeId <= 0)
+				throw new NodeOperationError(
+					this.getNode(),
+					'Employee ID is required for deleting assignment.',
+				);
+			if (!username)
+				throw new NodeOperationError(
+					this.getNode(),
+					'Username (idString) is required for deleting assignment.',
+				);
+			body.employeeId = employeeId;
+			body.username = username;
+		}
 
-        const url = `${baseURL}/backend/api/calls/v1/employeeAssignment`;
-        const requestOptions: IDataObject = {
-            method: 'DELETE',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            body,
-            json: true,
-        };
+		const url = `${baseURL}/backend/api/calls/v1/employeeAssignment`;
+		const requestOptions: IDataObject = {
+			method: 'DELETE',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
 
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to delete employee assignment: ${message}`);
-        }
-    }
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to delete employee assignment: ${message}`,
+			);
+		}
+	}
 
-    throw new NodeOperationError(this.getNode(), `Operation "${operation}" not supported by Calls.`);
+	throw new NodeOperationError(this.getNode(), `Operation "${operation}" not supported by Calls.`);
 }

--- a/nodes/tanss/sub/callsuser.ts
+++ b/nodes/tanss/sub/callsuser.ts
@@ -1,244 +1,279 @@
 import { IExecuteFunctions, INodeProperties, NodeOperationError, IDataObject } from 'n8n-workflow';
 
 export const callsUserOperations: INodeProperties[] = [
-    {
-        displayName: 'Operation',
-        name: 'operation',
-        type: 'options' as const,
-        noDataExpression: true,
-        displayOptions: {
-            show: { resource: ['callsuser'] },
-        },
-        options: [
-            {
-                name: 'Get a List of Phone Calls',
-                value: 'getCalls',
-                description: 'Retrieves a list of phone calls using filter settings',
-                action: 'Get calls',
-            },
-            {
-                name: 'Get Phone Call By ID',
-                value: 'getCallById',
-                description: 'Gets a specific phone call by its ID',
-                action: 'Get call by id',
-            },
-            {
-                name: 'Identifies a Phone Call',
-                value: 'identifyCall',
-                description: 'Tries to identify a phone call and resolve company and employeeId',
-                action: 'Identify call',
-            },
-        ],
-        default: 'getCalls',
-    },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options' as const,
+		noDataExpression: true,
+		displayOptions: {
+			show: { resource: ['callsuser'] },
+		},
+		options: [
+			{
+				name: 'Get a List of Phone Calls',
+				value: 'getCalls',
+				description: 'Retrieves a list of phone calls using filter settings',
+				action: 'Get calls',
+			},
+			{
+				name: 'Get Phone Call By ID',
+				value: 'getCallById',
+				description: 'Gets a specific phone call by its ID',
+				action: 'Get call by id',
+			},
+			{
+				name: 'Identifies a Phone Call',
+				value: 'identifyCall',
+				description: 'Tries to identify a phone call and resolve company and employeeId',
+				action: 'Identify call',
+			},
+		],
+		default: 'getCalls',
+	},
 ];
 
 export const callsUserFields: INodeProperties[] = [
-    {
-        displayName: 'API Token',
-        name: 'apiToken',
-        type: 'string' as const,
-        required: true,
-        typeOptions: { password: true },
-        default: '',
-        description: 'API token obtained from the TANSS API login',
-        displayOptions: { show: { resource: ['callsuser'] } },
-    },
+	{
+		displayName: 'API Token',
+		name: 'apiToken',
+		type: 'string' as const,
+		required: true,
+		typeOptions: { password: true },
+		default: '',
+		description: 'API token obtained from the TANSS API login',
+		displayOptions: { show: { resource: ['callsuser'] } },
+	},
 
-    {
-        displayName: 'Use Raw Filter JSON (Optional)',
-        name: 'filterJson',
-        type: 'string' as const,
-        default: '',
-        description:
-            'If provided (valid JSON), this object will be sent as the request body for the list call (overrides Filter Settings)',
-        displayOptions: {
-            show: { resource: ['callsuser'], operation: ['getCalls'] },
-        },
-    },
+	{
+		displayName: 'Use Raw Filter JSON (Optional)',
+		name: 'filterJson',
+		type: 'string' as const,
+		default: '',
+		description:
+			'If provided (valid JSON), this object will be sent as the request body for the list call (overrides Filter Settings)',
+		displayOptions: {
+			show: { resource: ['callsuser'], operation: ['getCalls'] },
+		},
+	},
 
-    {
-        displayName: 'Filter Settings',
-        name: 'getCallsFilters',
-        type: 'collection' as const,
-        placeholder: 'Add Filter',
-        displayOptions: { show: { resource: ['callsuser'], operation: ['getCalls'] } },
-        default: {},
-        options: [
-            { displayName: 'Timeframe From (Timestamp)', name: 'timeFrom', type: 'number' as const, default: 0 },
-            { displayName: 'Timeframe To (Timestamp)', name: 'timeTo', type: 'number' as const, default: 0 },
-            { displayName: 'Show Tries As Well', name: 'showTrysAsWell', type: 'boolean' as const, default: false },
-            { displayName: 'Number Filters (Comma Separated)', name: 'numberFilters', type: 'string' as const, default: '' },
-            { displayName: 'Employee ID', name: 'employeeIdFilter', type: 'number' as const, default: 0 },
-            { displayName: 'Company ID', name: 'companyIdFilter', type: 'number' as const, default: 0 },
-            { displayName: 'Number Infos', name: 'numberInfos', type: 'boolean' as const, default: false },
-            {
-                displayName: 'Directions',
-                name: 'directions',
-                type: 'multiOptions' as const,
-                options: [
-                    { name: 'INTERNAL', value: 'INTERNAL' },
-                    { name: 'INCOMING', value: 'INCOMING' },
-                    { name: 'OUTGOING', value: 'OUTGOING' },
-                ],
-                default: [],
-            },
-        ],
-    },
+	{
+		displayName: 'Filter Settings',
+		name: 'getCallsFilters',
+		type: 'collection' as const,
+		placeholder: 'Add Filter',
+		displayOptions: { show: { resource: ['callsuser'], operation: ['getCalls'] } },
+		default: {},
+		options: [
+			{
+				displayName: 'Timeframe From (Timestamp)',
+				name: 'timeFrom',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Timeframe To (Timestamp)',
+				name: 'timeTo',
+				type: 'number' as const,
+				default: 0,
+			},
+			{
+				displayName: 'Show Tries As Well',
+				name: 'showTrysAsWell',
+				type: 'boolean' as const,
+				default: false,
+			},
+			{
+				displayName: 'Number Filters (Comma Separated)',
+				name: 'numberFilters',
+				type: 'string' as const,
+				default: '',
+			},
+			{ displayName: 'Employee ID', name: 'employeeIdFilter', type: 'number' as const, default: 0 },
+			{ displayName: 'Company ID', name: 'companyIdFilter', type: 'number' as const, default: 0 },
+			{
+				displayName: 'Number Infos',
+				name: 'numberInfos',
+				type: 'boolean' as const,
+				default: false,
+			},
+			{
+				displayName: 'Directions',
+				name: 'directions',
+				type: 'multiOptions' as const,
+				options: [
+					{ name: 'INTERNAL', value: 'INTERNAL' },
+					{ name: 'INCOMING', value: 'INCOMING' },
+					{ name: 'OUTGOING', value: 'OUTGOING' },
+				],
+				default: [],
+			},
+		],
+	},
 
-    {
-        displayName: 'Phone Call ID',
-        name: 'phoneCallId',
-        type: 'number' as const,
-        default: 0,
-        description: 'ID of the phone call to fetch',
-        displayOptions: {
-            show: { resource: ['callsuser'], operation: ['getCallById'] },
-        },
-    },
-    {
-        displayName: 'From Phone Number',
-        name: 'fromPhoneNumber',
-        type: 'string' as const,
-        default: '',
-        required: true,
-        description: 'Phone number of the caller (= "from" number)',
-        displayOptions: {
-            show: { resource: ['callsuser'], operation: ['identifyCall'] },
-        },
-    },
-    {
-        displayName: 'To Phone Number',
-        name: 'toPhoneNumber',
-        type: 'string' as const,
-        default: '',
-        required: true,
-        description: 'Phone number of the called (= "to" number)',
-        displayOptions: {
-            show: { resource: ['callsuser'], operation: ['identifyCall'] },
-        },
-    },
+	{
+		displayName: 'Phone Call ID',
+		name: 'phoneCallId',
+		type: 'number' as const,
+		default: 0,
+		description: 'ID of the phone call to fetch',
+		displayOptions: {
+			show: { resource: ['callsuser'], operation: ['getCallById'] },
+		},
+	},
+	{
+		displayName: 'From Phone Number',
+		name: 'fromPhoneNumber',
+		type: 'string' as const,
+		default: '',
+		required: true,
+		description: 'Phone number of the caller (= "from" number)',
+		displayOptions: {
+			show: { resource: ['callsuser'], operation: ['identifyCall'] },
+		},
+	},
+	{
+		displayName: 'To Phone Number',
+		name: 'toPhoneNumber',
+		type: 'string' as const,
+		default: '',
+		required: true,
+		description: 'Phone number of the called (= "to" number)',
+		displayOptions: {
+			show: { resource: ['callsuser'], operation: ['identifyCall'] },
+		},
+	},
 ];
 
 export async function handleCallsUser(this: IExecuteFunctions, i: number) {
-    const operation = this.getNodeParameter('operation', i) as string;
-    const credentials = await this.getCredentials('tanssApi');
-    if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
+	const operation = this.getNodeParameter('operation', i) as string;
+	const credentials = await this.getCredentials('tanssApi');
+	if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
 
-    const apiToken = this.getNodeParameter('apiToken', i, '') as string;
-    const base = credentials.baseURL as string;
-    if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
+	const apiToken = this.getNodeParameter('apiToken', i, '') as string;
+	const base = credentials.baseURL as string;
+	if (!base) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
 
-    let url = '';
-    const requestOptions: {
-        method: 'GET' | 'PUT' | 'POST';
-        headers: { apiToken: string; 'Content-Type': string };
-        json: boolean;
-        body?: IDataObject;
-        url: string;
-    } = {
-        method: 'GET',
-        headers: { apiToken, 'Content-Type': 'application/json' },
-        json: true,
-        url,
-    };
+	let url = '';
+	const requestOptions: {
+		method: 'GET' | 'PUT' | 'POST';
+		headers: { apiToken: string; 'Content-Type': string };
+		json: boolean;
+		body?: IDataObject;
+		url: string;
+	} = {
+		method: 'GET',
+		headers: { apiToken, 'Content-Type': 'application/json' },
+		json: true,
+		url,
+	};
 
-    switch (operation) {
-        case 'getCalls': {
-            const filterJson = this.getNodeParameter('filterJson', i, '') as string;
-            let body: IDataObject = {};
+	switch (operation) {
+		case 'getCalls': {
+			const filterJson = this.getNodeParameter('filterJson', i, '') as string;
+			let body: IDataObject = {};
 
-            if (filterJson && filterJson.trim() !== '') {
-                try {
-                    const parsed = JSON.parse(filterJson);
-                    if (typeof parsed !== 'object' || parsed === null) {
-                        throw new Error('filterJson must be a JSON object.');
-                    }
-                    body = parsed as IDataObject;
-                } catch (err) {
-                    const msg = err instanceof Error ? err.message : String(err);
-                    throw new NodeOperationError(this.getNode(), `filterJson must be valid JSON: ${msg}`);
-                }
-            } else {
-                const filters = this.getNodeParameter('getCallsFilters', i, {}) as IDataObject;
+			if (filterJson && filterJson.trim() !== '') {
+				try {
+					const parsed = JSON.parse(filterJson);
+					if (typeof parsed !== 'object' || parsed === null) {
+						throw new Error('filterJson must be a JSON object.');
+					}
+					body = parsed as IDataObject;
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					throw new NodeOperationError(this.getNode(), `filterJson must be valid JSON: ${msg}`);
+				}
+			} else {
+				const filters = this.getNodeParameter('getCallsFilters', i, {}) as IDataObject;
 
-                const timeFrom = Number(filters.timeFrom) || 0;
-                const timeTo = Number(filters.timeTo) || 0;
-                if (timeFrom || timeTo) {
-                    const timeframe: IDataObject = {};
-                    if (timeFrom > 0) timeframe.from = timeFrom;
-                    if (timeTo > 0) timeframe.to = timeTo;
-                    body.timeframe = timeframe;
-                }
+				const timeFrom = Number(filters.timeFrom) || 0;
+				const timeTo = Number(filters.timeTo) || 0;
+				if (timeFrom || timeTo) {
+					const timeframe: IDataObject = {};
+					if (timeFrom > 0) timeframe.from = timeFrom;
+					if (timeTo > 0) timeframe.to = timeTo;
+					body.timeframe = timeframe;
+				}
 
-                if (filters.showTrysAsWell === true) body.showTrysAsWell = true;
+				if (filters.showTrysAsWell === true) body.showTrysAsWell = true;
 
-                if (filters.numberFilters && typeof filters.numberFilters === 'string' && filters.numberFilters.trim() !== '') {
-                    body.numberFilters = filters.numberFilters.split(',').map(s => s.trim());
-                }
+				if (
+					filters.numberFilters &&
+					typeof filters.numberFilters === 'string' &&
+					filters.numberFilters.trim() !== ''
+				) {
+					body.numberFilters = filters.numberFilters.split(',').map((s) => s.trim());
+				}
 
-                const employeeIdFilter = Number(filters.employeeIdFilter) || 0;
-                if (employeeIdFilter > 0)
-                    body.employeeId = employeeIdFilter;
+				const employeeIdFilter = Number(filters.employeeIdFilter) || 0;
+				if (employeeIdFilter > 0) body.employeeId = employeeIdFilter;
 
-                const companyIdFilter = Number(filters.companyIdFilter) || 0;
-                if (companyIdFilter > 0)
-                    body.companyId = companyIdFilter;
+				const companyIdFilter = Number(filters.companyIdFilter) || 0;
+				if (companyIdFilter > 0) body.companyId = companyIdFilter;
 
-                if (filters.numberInfos === true) body.numberInfos = true;
+				if (filters.numberInfos === true) body.numberInfos = true;
 
-                if (filters.directions && Array.isArray(filters.directions) && filters.directions.length)
-                    body.directions = filters.directions;
-            }
+				if (filters.directions && Array.isArray(filters.directions) && filters.directions.length)
+					body.directions = filters.directions;
+			}
 
-            url = `${base.replace(/\/+$/, '')}/backend/api/v1/phoneCalls`;
-            requestOptions.method = 'PUT';
-            requestOptions.url = url;
-            requestOptions.body = body;
-            break;
-        }
+			url = `${base.replace(/\/+$/, '')}/backend/api/v1/phoneCalls`;
+			requestOptions.method = 'PUT';
+			requestOptions.url = url;
+			requestOptions.body = body;
+			break;
+		}
 
-        case 'getCallById': {
-            const phoneCallId = this.getNodeParameter('phoneCallId', i, 0) as number;
-            if (!phoneCallId || phoneCallId <= 0)
-                throw new NodeOperationError(this.getNode(), 'A valid Phone Call ID is required.');
+		case 'getCallById': {
+			const phoneCallId = this.getNodeParameter('phoneCallId', i, 0) as number;
+			if (!phoneCallId || phoneCallId <= 0)
+				throw new NodeOperationError(this.getNode(), 'A valid Phone Call ID is required.');
 
-            url = `${base.replace(/\/+$/, '')}/backend/api/v1/phoneCalls/${encodeURIComponent(String(phoneCallId))}`;
-            requestOptions.method = 'GET';
-            requestOptions.url = url;
-            break;
-        }
+			url = `${base.replace(/\/+$/, '')}/backend/api/v1/phoneCalls/${encodeURIComponent(String(phoneCallId))}`;
+			requestOptions.method = 'GET';
+			requestOptions.url = url;
+			break;
+		}
 
-        case 'identifyCall': {
-            const fromPhoneNumber = this.getNodeParameter('fromPhoneNumber', i, '') as string;
-            const toPhoneNumber = this.getNodeParameter('toPhoneNumber', i, '') as string;
+		case 'identifyCall': {
+			const fromPhoneNumber = this.getNodeParameter('fromPhoneNumber', i, '') as string;
+			const toPhoneNumber = this.getNodeParameter('toPhoneNumber', i, '') as string;
 
-            if (!fromPhoneNumber || fromPhoneNumber.trim() === '')
-                throw new NodeOperationError(this.getNode(), 'fromPhoneNumber is required for identification.');
-            if (!toPhoneNumber || toPhoneNumber.trim() === '')
-                throw new NodeOperationError(this.getNode(), 'toPhoneNumber is required for identification.');
+			if (!fromPhoneNumber || fromPhoneNumber.trim() === '')
+				throw new NodeOperationError(
+					this.getNode(),
+					'fromPhoneNumber is required for identification.',
+				);
+			if (!toPhoneNumber || toPhoneNumber.trim() === '')
+				throw new NodeOperationError(
+					this.getNode(),
+					'toPhoneNumber is required for identification.',
+				);
 
-            const body: IDataObject = {
-                fromPhoneNumber: fromPhoneNumber.trim(),
-                toPhoneNumber: toPhoneNumber.trim(),
-            };
+			const body: IDataObject = {
+				fromPhoneNumber: fromPhoneNumber.trim(),
+				toPhoneNumber: toPhoneNumber.trim(),
+			};
 
-            url = `${base.replace(/\/+$/, '')}/backend/api/v1/phoneCalls/identify`;
-            requestOptions.method = 'POST';
-            requestOptions.url = url;
-            requestOptions.body = body;
-            break;
-        }
+			url = `${base.replace(/\/+$/, '')}/backend/api/v1/phoneCalls/identify`;
+			requestOptions.method = 'POST';
+			requestOptions.url = url;
+			requestOptions.body = body;
+			break;
+		}
 
-        default:
-            throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`);
-    }
+		default:
+			throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`);
+	}
 
-    try {
-    const responseData = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-        return responseData;
-    } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new NodeOperationError(this.getNode(), `Failed to execute ${operation}: ${message}`);
-    }
+	try {
+		const responseData = await this.helpers.httpRequest(
+			requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+		);
+		return responseData;
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new NodeOperationError(this.getNode(), `Failed to execute ${operation}: ${message}`);
+	}
 }

--- a/nodes/tanss/sub/hddTypes.ts
+++ b/nodes/tanss/sub/hddTypes.ts
@@ -8,11 +8,36 @@ export const hddTypesOperations: INodeProperties[] = [
 		noDataExpression: true,
 		displayOptions: { show: { resource: ['hddTypes'] } },
 		options: [
-			{ name: 'Create HDD Type', value: 'createHddType', description: 'Creates a new hdd type', action: 'Create an HDD type' },
-			{ name: 'Delete HDD Type', value: 'deleteHddType', description: 'Deletes a hdd type', action: 'Delete an HDD type' },
-			{ name: 'Get All HDD Types', value: 'getAllHddTypes', description: 'Gets a list of all hdd types', action: 'Get all HDD types' },
-			{ name: 'Get HDD Type', value: 'getHddTypeById', description: 'Gets a specific hdd type', action: 'Get an HDD type' },
-			{ name: 'Update HDD Type', value: 'updateHddType', description: 'Updates an existing hdd type', action: 'Update an HDD type' },
+			{
+				name: 'Create HDD Type',
+				value: 'createHddType',
+				description: 'Creates a new hdd type',
+				action: 'Create an HDD type',
+			},
+			{
+				name: 'Delete HDD Type',
+				value: 'deleteHddType',
+				description: 'Deletes a hdd type',
+				action: 'Delete an HDD type',
+			},
+			{
+				name: 'Get All HDD Types',
+				value: 'getAllHddTypes',
+				description: 'Gets a list of all hdd types',
+				action: 'Get all HDD types',
+			},
+			{
+				name: 'Get HDD Type',
+				value: 'getHddTypeById',
+				description: 'Gets a specific hdd type',
+				action: 'Get an HDD type',
+			},
+			{
+				name: 'Update HDD Type',
+				value: 'updateHddType',
+				description: 'Updates an existing hdd type',
+				action: 'Update an HDD type',
+			},
 		],
 		default: 'getAllHddTypes',
 	},
@@ -35,7 +60,12 @@ export const hddTypesFields: INodeProperties[] = [
 		type: 'number' as const,
 		default: 0,
 		description: 'ID of the HDD type',
-		displayOptions: { show: { resource: ['hddTypes'], operation: ['updateHddType','getHddTypeById','deleteHddType'] } },
+		displayOptions: {
+			show: {
+				resource: ['hddTypes'],
+				operation: ['updateHddType', 'getHddTypeById', 'deleteHddType'],
+			},
+		},
 	},
 	{
 		displayName: 'Create HDD Type Fields',
@@ -90,8 +120,12 @@ export async function handleHddTypes(this: IExecuteFunctions, i: number) {
 		case 'createHddType': {
 			url = `${credentials.baseURL}/backend/api/v1/hddTypes`;
 			requestOptions.method = 'POST';
-			const createHddTypeFields = this.getNodeParameter('createHddTypeFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(createHddTypeFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields provided for HDD type creation.');
+			const createHddTypeFields = this.getNodeParameter('createHddTypeFields', i, {}) as Record<
+				string,
+				unknown
+			>;
+			if (Object.keys(createHddTypeFields).length === 0)
+				throw new NodeOperationError(this.getNode(), 'No fields provided for HDD type creation.');
 			requestOptions.body = createHddTypeFields;
 			break;
 		}
@@ -113,20 +147,30 @@ export async function handleHddTypes(this: IExecuteFunctions, i: number) {
 		case 'updateHddType': {
 			url = `${credentials.baseURL}/backend/api/v1/hddTypes/${hddTypeId}`;
 			requestOptions.method = 'PUT';
-			const updateHddTypeFields = this.getNodeParameter('updateHddTypeFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(updateHddTypeFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields provided for HDD type update.');
+			const updateHddTypeFields = this.getNodeParameter('updateHddTypeFields', i, {}) as Record<
+				string,
+				unknown
+			>;
+			if (Object.keys(updateHddTypeFields).length === 0)
+				throw new NodeOperationError(this.getNode(), 'No fields provided for HDD type update.');
 			requestOptions.body = updateHddTypeFields;
 			break;
 		}
 		default:
-			throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized for HDD Types.`);
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized for HDD Types.`,
+			);
 	}
 
 	requestOptions.url = url;
 
 	try {
 		type FullResponse = { statusCode: number; body?: unknown };
-		const options = { ...requestOptions, returnFullResponse: true } as unknown as import('n8n-workflow').IHttpRequestOptions;
+		const options = {
+			...requestOptions,
+			returnFullResponse: true,
+		} as unknown as import('n8n-workflow').IHttpRequestOptions;
 		const fullResponse = (await this.helpers.httpRequest(options)) as unknown as FullResponse;
 		if (requestOptions.method === 'DELETE') {
 			return { success: fullResponse.statusCode === 204, statusCode: fullResponse.statusCode };

--- a/nodes/tanss/sub/manufacturers.ts
+++ b/nodes/tanss/sub/manufacturers.ts
@@ -8,11 +8,36 @@ export const manufacturersOperations: INodeProperties[] = [
 		noDataExpression: true,
 		displayOptions: { show: { resource: ['manufacturers'] } },
 		options: [
-			{ name: 'Create Manufacturer', value: 'createManufacturer', description: 'Creates a new manufacturer', action: 'Create a manufacturer' },
-			{ name: 'Delete Manufacturer', value: 'deleteManufacturer', description: 'Deletes a manufacturer', action: 'Delete a manufacturer' },
-			{ name: 'Get All Manufacturers', value: 'getAllManufacturers', description: 'Gets a list of all manufacturers', action: 'Get all manufacturers' },
-			{ name: 'Get Manufacturer', value: 'getManufacturerById', description: 'Gets a specific manufacturer', action: 'Get a manufacturer' },
-			{ name: 'Update Manufacturer', value: 'updateManufacturer', description: 'Updates an existing manufacturer', action: 'Update a manufacturer' },
+			{
+				name: 'Create Manufacturer',
+				value: 'createManufacturer',
+				description: 'Creates a new manufacturer',
+				action: 'Create a manufacturer',
+			},
+			{
+				name: 'Delete Manufacturer',
+				value: 'deleteManufacturer',
+				description: 'Deletes a manufacturer',
+				action: 'Delete a manufacturer',
+			},
+			{
+				name: 'Get All Manufacturers',
+				value: 'getAllManufacturers',
+				description: 'Gets a list of all manufacturers',
+				action: 'Get all manufacturers',
+			},
+			{
+				name: 'Get Manufacturer',
+				value: 'getManufacturerById',
+				description: 'Gets a specific manufacturer',
+				action: 'Get a manufacturer',
+			},
+			{
+				name: 'Update Manufacturer',
+				value: 'updateManufacturer',
+				description: 'Updates an existing manufacturer',
+				action: 'Update a manufacturer',
+			},
 		],
 		default: 'getAllManufacturers',
 	},
@@ -35,7 +60,12 @@ export const manufacturersFields: INodeProperties[] = [
 		type: 'number' as const,
 		default: 0,
 		description: 'ID of the manufacturer',
-		displayOptions: { show: { resource: ['manufacturers'], operation: ['updateManufacturer','getManufacturerById','deleteManufacturer'] } },
+		displayOptions: {
+			show: {
+				resource: ['manufacturers'],
+				operation: ['updateManufacturer', 'getManufacturerById', 'deleteManufacturer'],
+			},
+		},
 	},
 	{
 		displayName: 'Create Manufacturer Fields',
@@ -90,8 +120,16 @@ export async function handleManufacturers(this: IExecuteFunctions, i: number) {
 		case 'createManufacturer': {
 			url = `${credentials.baseURL}/backend/api/v1/manufacturers`;
 			requestOptions.method = 'POST';
-			const createManufacturerFields = this.getNodeParameter('createManufacturerFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(createManufacturerFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields provided for manufacturer creation.');
+			const createManufacturerFields = this.getNodeParameter(
+				'createManufacturerFields',
+				i,
+				{},
+			) as Record<string, unknown>;
+			if (Object.keys(createManufacturerFields).length === 0)
+				throw new NodeOperationError(
+					this.getNode(),
+					'No fields provided for manufacturer creation.',
+				);
 			requestOptions.body = createManufacturerFields;
 			break;
 		}
@@ -113,20 +151,31 @@ export async function handleManufacturers(this: IExecuteFunctions, i: number) {
 		case 'updateManufacturer': {
 			url = `${credentials.baseURL}/backend/api/v1/manufacturers/${manufacturerId}`;
 			requestOptions.method = 'PUT';
-			const updateManufacturerFields = this.getNodeParameter('updateManufacturerFields', i, {}) as Record<string, unknown>;
-			if (Object.keys(updateManufacturerFields).length === 0) throw new NodeOperationError(this.getNode(), 'No fields provided for manufacturer update.');
+			const updateManufacturerFields = this.getNodeParameter(
+				'updateManufacturerFields',
+				i,
+				{},
+			) as Record<string, unknown>;
+			if (Object.keys(updateManufacturerFields).length === 0)
+				throw new NodeOperationError(this.getNode(), 'No fields provided for manufacturer update.');
 			requestOptions.body = updateManufacturerFields;
 			break;
 		}
 		default:
-			throw new NodeOperationError(this.getNode(), `The operation "${operation}" is not recognized for Manufacturers.`);
+			throw new NodeOperationError(
+				this.getNode(),
+				`The operation "${operation}" is not recognized for Manufacturers.`,
+			);
 	}
 
 	requestOptions.url = url;
 
 	try {
 		type FullResponse = { statusCode: number; body?: unknown };
-		const options = { ...requestOptions, returnFullResponse: true } as unknown as import('n8n-workflow').IHttpRequestOptions;
+		const options = {
+			...requestOptions,
+			returnFullResponse: true,
+		} as unknown as import('n8n-workflow').IHttpRequestOptions;
 		const fullResponse = (await this.helpers.httpRequest(options)) as unknown as FullResponse;
 		if (requestOptions.method === 'DELETE') {
 			return { success: fullResponse.statusCode === 204, statusCode: fullResponse.statusCode };

--- a/nodes/tanss/sub/timestamp.ts
+++ b/nodes/tanss/sub/timestamp.ts
@@ -1,627 +1,898 @@
-import { IExecuteFunctions, INodeProperties, NodeOperationError, IDataObject, IHttpRequestOptions } from 'n8n-workflow';
+import {
+	IExecuteFunctions,
+	INodeProperties,
+	NodeOperationError,
+	IDataObject,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
 
 export const timestampOperations: INodeProperties[] = [
-    {
-        displayName: 'Operation',
-        name: 'operation',
-        type: 'options' as const,
-        noDataExpression: true,
-        displayOptions: {
-            show: {
-                resource: ['timestamps'],
-            },
-        },
-        options: [
-            { name: 'Get Timestamps', value: 'getTimestamps', description: 'Gets a list of timestamps from a given period', action: 'Get timestamps' },
-            { name: 'Get Timestamp Info', value: 'getTimestampInfo', description: 'Gets the timestamp infos for a given time period', action: 'Get timestamp info' },
-            { name: 'Get Timestamp Statistics', value: 'getTimestampStatistics', description: 'Gets the timestamp infos for a given time period (with statistical values)', action: 'Get timestamp statistics' },
-            { name: 'Create Timestamp', value: 'createTimestamp', description: 'Writes a timestamp into the database', action: 'Create timestamp' },
-            { name: 'Update Timestamp', value: 'updateTimestamp', description: 'Edits a single timestamp', action: 'Update timestamp' },
-            { name: 'Save Day Timestamps', value: 'saveDayTimestamps', description: 'Writes the timestamps of a whole day into the database at once', action: 'Save day timestamps' },
-            { name: 'Create Day Closing(s)', value: 'createDayClosing', description: 'Creates one or more day closings', action: 'Create day closing(s)' },
-            { name: 'Delete Day Closing(s)', value: 'deleteDayClosing', description: 'Deletes one or more day closings (undo)', action: 'Delete day closing(s)' },
-            { name: 'Get Day Closing Till Date', value: 'getDayClosingTillDate', description: 'Gets all infos about last dayclosings for employees', action: 'Get day closing till date' },
-            { name: 'Create Day Closings Till Date', value: 'createDayClosingsTillDate', description: 'Creates missing dayClosings for given employees till a date', action: 'Create day closings till date' },
-            { name: 'Set Initial Balance', value: 'setInitialBalance', description: 'Sets the initial balance for an employee', action: 'Set initial balance' },
-            { name: 'Get Pause Configs', value: 'getPauseConfigs', description: 'Gets a list of all pause configs', action: 'Get pause configs' },
-            { name: 'Create Pause Config', value: 'createPauseConfig', description: 'Creates a pause config', action: 'Create pause config' },
-            { name: 'Update Pause Config', value: 'updatePauseConfig', description: 'Updates a pause config', action: 'Update pause config' },
-            { name: 'Delete Pause Config', value: 'deletePauseConfig', description: 'Deletes a pause config', action: 'Delete pause config' },
-        ],
-        default: 'getTimestamps',
-    },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options' as const,
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['timestamps'],
+			},
+		},
+		options: [
+			{
+				name: 'Get Timestamps',
+				value: 'getTimestamps',
+				description: 'Gets a list of timestamps from a given period',
+				action: 'Get timestamps',
+			},
+			{
+				name: 'Get Timestamp Info',
+				value: 'getTimestampInfo',
+				description: 'Gets the timestamp infos for a given time period',
+				action: 'Get timestamp info',
+			},
+			{
+				name: 'Get Timestamp Statistics',
+				value: 'getTimestampStatistics',
+				description: 'Gets the timestamp infos for a given time period (with statistical values)',
+				action: 'Get timestamp statistics',
+			},
+			{
+				name: 'Create Timestamp',
+				value: 'createTimestamp',
+				description: 'Writes a timestamp into the database',
+				action: 'Create timestamp',
+			},
+			{
+				name: 'Update Timestamp',
+				value: 'updateTimestamp',
+				description: 'Edits a single timestamp',
+				action: 'Update timestamp',
+			},
+			{
+				name: 'Save Day Timestamps',
+				value: 'saveDayTimestamps',
+				description: 'Writes the timestamps of a whole day into the database at once',
+				action: 'Save day timestamps',
+			},
+			{
+				name: 'Create Day Closing(s)',
+				value: 'createDayClosing',
+				description: 'Creates one or more day closings',
+				action: 'Create day closing(s)',
+			},
+			{
+				name: 'Delete Day Closing(s)',
+				value: 'deleteDayClosing',
+				description: 'Deletes one or more day closings (undo)',
+				action: 'Delete day closing(s)',
+			},
+			{
+				name: 'Get Day Closing Till Date',
+				value: 'getDayClosingTillDate',
+				description: 'Gets all infos about last dayclosings for employees',
+				action: 'Get day closing till date',
+			},
+			{
+				name: 'Create Day Closings Till Date',
+				value: 'createDayClosingsTillDate',
+				description: 'Creates missing dayClosings for given employees till a date',
+				action: 'Create day closings till date',
+			},
+			{
+				name: 'Set Initial Balance',
+				value: 'setInitialBalance',
+				description: 'Sets the initial balance for an employee',
+				action: 'Set initial balance',
+			},
+			{
+				name: 'Get Pause Configs',
+				value: 'getPauseConfigs',
+				description: 'Gets a list of all pause configs',
+				action: 'Get pause configs',
+			},
+			{
+				name: 'Create Pause Config',
+				value: 'createPauseConfig',
+				description: 'Creates a pause config',
+				action: 'Create pause config',
+			},
+			{
+				name: 'Update Pause Config',
+				value: 'updatePauseConfig',
+				description: 'Updates a pause config',
+				action: 'Update pause config',
+			},
+			{
+				name: 'Delete Pause Config',
+				value: 'deletePauseConfig',
+				description: 'Deletes a pause config',
+				action: 'Delete pause config',
+			},
+		],
+		default: 'getTimestamps',
+	},
 ];
 
 export const timestampFields: INodeProperties[] = [
-    {
-        displayName: 'API Token',
-        name: 'apiToken',
-        type: 'string' as const,
-        required: true,
-        typeOptions: { password: true },
-        default: '',
-        description: 'API token obtained from the TANSS API login',
-        displayOptions: { show: { resource: ['timestamps'] } },
-    },
+	{
+		displayName: 'API Token',
+		name: 'apiToken',
+		type: 'string' as const,
+		required: true,
+		typeOptions: { password: true },
+		default: '',
+		description: 'API token obtained from the TANSS API login',
+		displayOptions: { show: { resource: ['timestamps'] } },
+	},
 
-    // getTimestamps / info / statistics params
-    {
-        displayName: 'From (Timestamp)',
-        name: 'from',
-        type: 'number' as const,
-        default: 0,
-        description: 'Timestamp of start of period. If omitted, beginning of current day is used by the API.',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['getTimestamps', 'getTimestampInfo', 'getTimestampStatistics'] } },
-    },
-    {
-        displayName: 'Till (Timestamp)',
-        name: 'till',
-        type: 'number' as const,
-        default: 0,
-        description: 'Timestamp of end of period. If omitted, end of current day is used by the API.',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['getTimestamps', 'getTimestampInfo', 'getTimestampStatistics'] } },
-    },
-    {
-        displayName: 'Employee IDs (Comma Separated)',
-        name: 'employeeIds',
-        type: 'string' as const,
-        default: '',
-        description: 'Comma-separated list of employee IDs for which statistics shall be generated (only for statistics operation)',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['getTimestampStatistics'] } },
-    },
+	// getTimestamps / info / statistics params
+	{
+		displayName: 'From (Timestamp)',
+		name: 'from',
+		type: 'number' as const,
+		default: 0,
+		description:
+			'Timestamp of start of period. If omitted, beginning of current day is used by the API.',
+		displayOptions: {
+			show: {
+				resource: ['timestamps'],
+				operation: ['getTimestamps', 'getTimestampInfo', 'getTimestampStatistics'],
+			},
+		},
+	},
+	{
+		displayName: 'Till (Timestamp)',
+		name: 'till',
+		type: 'number' as const,
+		default: 0,
+		description: 'Timestamp of end of period. If omitted, end of current day is used by the API.',
+		displayOptions: {
+			show: {
+				resource: ['timestamps'],
+				operation: ['getTimestamps', 'getTimestampInfo', 'getTimestampStatistics'],
+			},
+		},
+	},
+	{
+		displayName: 'Employee IDs (Comma Separated)',
+		name: 'employeeIds',
+		type: 'string' as const,
+		default: '',
+		description:
+			'Comma-separated list of employee IDs for which statistics shall be generated (only for statistics operation)',
+		displayOptions: { show: { resource: ['timestamps'], operation: ['getTimestampStatistics'] } },
+	},
 
-    // createTimestamp fields
-    {
-        displayName: 'Auto Pause',
-        name: 'autoPause',
-        type: 'boolean' as const,
-        default: false,
-        description: 'If true, a pause will automatically be inserted if minimum pause is not met',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createTimestamp'] } },
-    },
-    {
-        displayName: 'Employee ID',
-        name: 'employeeId',
-        type: 'number' as const,
-        default: 0,
-        description: 'ID of the employee',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createTimestamp', 'updateTimestamp'] } },
-    },
-    {
-        displayName: 'Date (Timestamp)',
-        name: 'date',
-        type: 'number' as const,
-        default: 0,
-        description: 'Timestamp (integer) for the timestamp date',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createTimestamp', 'updateTimestamp'] } },
-    },
-    {
-        displayName: 'State',
-        name: 'state',
-        type: 'options' as const,
-        options: [
-            { name: 'ON', value: 'ON' }, { name: 'OFF', value: 'OFF' }, { name: 'PAUSE_START', value: 'PAUSE_START' }, { name: 'PAUSE_END', value: 'PAUSE_END' },
-        ],
-        default: 'ON',
-        description: 'Determines the state for the timestamp',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createTimestamp', 'updateTimestamp'] } },
-    },
-    {
-        displayName: 'Type',
-        name: 'type',
-        type: 'options' as const,
-        options: [
-            { name: 'WORK', value: 'WORK' }, { name: 'INHOUSE', value: 'INHOUSE' }, { name: 'ERRAND', value: 'ERRAND' },
-            { name: 'VACATION', value: 'VACATION' }, { name: 'ILLNESS', value: 'ILLNESS' }, { name: 'ABSENCE_PAID', value: 'ABSENCE_PAID' },
-            { name: 'ABSENCE_UNPAID', value: 'ABSENCE_UNPAID' }, { name: 'OVERTIME', value: 'OVERTIME' }, { name: 'DOCUMENTED_SUPPORT', value: 'DOCUMENTED_SUPPORT' },
-        ],
-        default: 'WORK',
-        description: 'Determines the type for the timestamp',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createTimestamp', 'updateTimestamp'] } },
-    },
+	// createTimestamp fields
+	{
+		displayName: 'Auto Pause',
+		name: 'autoPause',
+		type: 'boolean' as const,
+		default: false,
+		description: 'If true, a pause will automatically be inserted if minimum pause is not met',
+		displayOptions: { show: { resource: ['timestamps'], operation: ['createTimestamp'] } },
+	},
+	{
+		displayName: 'Employee ID',
+		name: 'employeeId',
+		type: 'number' as const,
+		default: 0,
+		description: 'ID of the employee',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['createTimestamp', 'updateTimestamp'] },
+		},
+	},
+	{
+		displayName: 'Date (Timestamp)',
+		name: 'date',
+		type: 'number' as const,
+		default: 0,
+		description: 'Timestamp (integer) for the timestamp date',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['createTimestamp', 'updateTimestamp'] },
+		},
+	},
+	{
+		displayName: 'State',
+		name: 'state',
+		type: 'options' as const,
+		options: [
+			{ name: 'ON', value: 'ON' },
+			{ name: 'OFF', value: 'OFF' },
+			{ name: 'PAUSE_START', value: 'PAUSE_START' },
+			{ name: 'PAUSE_END', value: 'PAUSE_END' },
+		],
+		default: 'ON',
+		description: 'Determines the state for the timestamp',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['createTimestamp', 'updateTimestamp'] },
+		},
+	},
+	{
+		displayName: 'Type',
+		name: 'type',
+		type: 'options' as const,
+		options: [
+			{ name: 'WORK', value: 'WORK' },
+			{ name: 'INHOUSE', value: 'INHOUSE' },
+			{ name: 'ERRAND', value: 'ERRAND' },
+			{ name: 'VACATION', value: 'VACATION' },
+			{ name: 'ILLNESS', value: 'ILLNESS' },
+			{ name: 'ABSENCE_PAID', value: 'ABSENCE_PAID' },
+			{ name: 'ABSENCE_UNPAID', value: 'ABSENCE_UNPAID' },
+			{ name: 'OVERTIME', value: 'OVERTIME' },
+			{ name: 'DOCUMENTED_SUPPORT', value: 'DOCUMENTED_SUPPORT' },
+		],
+		default: 'WORK',
+		description: 'Determines the type for the timestamp',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['createTimestamp', 'updateTimestamp'] },
+		},
+	},
 
-    // updateTimestamp path param
-    {
-        displayName: 'Timestamp ID',
-        name: 'timestampId',
-        type: 'number' as const,
-        default: 0,
-        description: 'ID of the timestamp to edit',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['updateTimestamp'] } },
-    },
+	// updateTimestamp path param
+	{
+		displayName: 'Timestamp ID',
+		name: 'timestampId',
+		type: 'number' as const,
+		default: 0,
+		description: 'ID of the timestamp to edit',
+		displayOptions: { show: { resource: ['timestamps'], operation: ['updateTimestamp'] } },
+	},
 
-    // saveDayTimestamps fields
-    {
-        displayName: 'Employee ID (Day)',
-        name: 'employeeIdDay',
-        type: 'number' as const,
-        default: 0,
-        description: 'Employee ID for saving day timestamps (path param)',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['saveDayTimestamps'] } },
-    },
-    {
-        displayName: 'Day',
-        name: 'day',
-        type: 'string' as const,
-        default: '',
-        description: 'Day in YYYY-mm-dd format',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['saveDayTimestamps'] } },
-    },
-    {
-        displayName: 'Timestamps JSON',
-        name: 'timestampsJson',
-        type: 'string' as const,
-        default: '[]',
-        description: 'JSON array of timestamp objects to save for the day (see docs)',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['saveDayTimestamps'] } },
-    },
+	// saveDayTimestamps fields
+	{
+		displayName: 'Employee ID (Day)',
+		name: 'employeeIdDay',
+		type: 'number' as const,
+		default: 0,
+		description: 'Employee ID for saving day timestamps (path param)',
+		displayOptions: { show: { resource: ['timestamps'], operation: ['saveDayTimestamps'] } },
+	},
+	{
+		displayName: 'Day',
+		name: 'day',
+		type: 'string' as const,
+		default: '',
+		description: 'Day in YYYY-mm-dd format',
+		displayOptions: { show: { resource: ['timestamps'], operation: ['saveDayTimestamps'] } },
+	},
+	{
+		displayName: 'Timestamps JSON',
+		name: 'timestampsJson',
+		type: 'string' as const,
+		default: '[]',
+		description: 'JSON array of timestamp objects to save for the day (see docs)',
+		displayOptions: { show: { resource: ['timestamps'], operation: ['saveDayTimestamps'] } },
+	},
 
-    // dayClosing create/delete payload
-    {
-        displayName: 'Day Closings JSON',
-        name: 'dayClosingsJson',
-        type: 'string' as const,
-        default: '[]',
-        description: 'JSON array of day closing identifiers [{ "employeeId": 1, "date":"YYYY-mm-dd" }, ...]',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createDayClosing', 'deleteDayClosing'] } },
-    },
+	// dayClosing create/delete payload
+	{
+		displayName: 'Day Closings JSON',
+		name: 'dayClosingsJson',
+		type: 'string' as const,
+		default: '[]',
+		description:
+			'JSON array of day closing identifiers [{ "employeeId": 1, "date":"YYYY-mm-dd" }, ...]',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['createDayClosing', 'deleteDayClosing'] },
+		},
+	},
 
-    // createDayClosingsTillDate fields
-    {
-        displayName: 'Till Date',
-        name: 'tillDate',
-        type: 'string' as const,
-        default: '',
-        description: 'End date (YYYY-MM-DD) to create dayClosings till',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createDayClosingsTillDate'] } },
-    },
-    {
-        displayName: 'Employee IDs JSON',
-        name: 'employeeIdsJson',
-        type: 'string' as const,
-        default: '[]',
-        description: 'JSON array of integers: employee IDs to create dayClosings for',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createDayClosingsTillDate'] } },
-    },
+	// createDayClosingsTillDate fields
+	{
+		displayName: 'Till Date',
+		name: 'tillDate',
+		type: 'string' as const,
+		default: '',
+		description: 'End date (YYYY-MM-DD) to create dayClosings till',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['createDayClosingsTillDate'] },
+		},
+	},
+	{
+		displayName: 'Employee IDs JSON',
+		name: 'employeeIdsJson',
+		type: 'string' as const,
+		default: '[]',
+		description: 'JSON array of integers: employee IDs to create dayClosings for',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['createDayClosingsTillDate'] },
+		},
+	},
 
-    // setInitialBalance fields
-    {
-        displayName: 'Employee ID (Initial)',
-        name: 'employeeIdInitial',
-        type: 'number' as const,
-        default: 0,
-        description: 'Employee ID (path param) for initial balance',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['setInitialBalance'] } },
-    },
-    {
-        displayName: 'Initial Balance (Minutes)',
-        name: 'initialBalance',
-        type: 'number' as const,
-        default: 0,
-        description: 'Initial balance in minutes',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['setInitialBalance'] } },
-    },
+	// setInitialBalance fields
+	{
+		displayName: 'Employee ID (Initial)',
+		name: 'employeeIdInitial',
+		type: 'number' as const,
+		default: 0,
+		description: 'Employee ID (path param) for initial balance',
+		displayOptions: { show: { resource: ['timestamps'], operation: ['setInitialBalance'] } },
+	},
+	{
+		displayName: 'Initial Balance (Minutes)',
+		name: 'initialBalance',
+		type: 'number' as const,
+		default: 0,
+		description: 'Initial balance in minutes',
+		displayOptions: { show: { resource: ['timestamps'], operation: ['setInitialBalance'] } },
+	},
 
-    // pauseConfigs fields
-    {
-        displayName: 'Pause Config ID',
-        name: 'pauseConfigId',
-        type: 'number' as const,
-        default: 0,
-        description: 'ID of the pause config (for update/delete)',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['updatePauseConfig', 'deletePauseConfig'] } },
-    },
-    {
-        displayName: 'From Minutes',
-        name: 'fromMinutes',
-        type: 'number' as const,
-        default: 0,
-        description: 'Minutes needed to require a minimum pause',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createPauseConfig', 'updatePauseConfig'] } },
-    },
-    {
-        displayName: 'Minimum Pause (Minutes)',
-        name: 'minimumPause',
-        type: 'number' as const,
-        default: 0,
-        description: 'Minimum pause in minutes',
-        displayOptions: { show: { resource: ['timestamps'], operation: ['createPauseConfig', 'updatePauseConfig'] } },
-    },
+	// pauseConfigs fields
+	{
+		displayName: 'Pause Config ID',
+		name: 'pauseConfigId',
+		type: 'number' as const,
+		default: 0,
+		description: 'ID of the pause config (for update/delete)',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['updatePauseConfig', 'deletePauseConfig'] },
+		},
+	},
+	{
+		displayName: 'From Minutes',
+		name: 'fromMinutes',
+		type: 'number' as const,
+		default: 0,
+		description: 'Minutes needed to require a minimum pause',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['createPauseConfig', 'updatePauseConfig'] },
+		},
+	},
+	{
+		displayName: 'Minimum Pause (Minutes)',
+		name: 'minimumPause',
+		type: 'number' as const,
+		default: 0,
+		description: 'Minimum pause in minutes',
+		displayOptions: {
+			show: { resource: ['timestamps'], operation: ['createPauseConfig', 'updatePauseConfig'] },
+		},
+	},
 ];
 
 export async function handleTimestamps(this: IExecuteFunctions, i: number) {
-    const operation = this.getNodeParameter('operation', i) as string;
-    const allowed = [
-        'getTimestamps',
-        'getTimestampInfo',
-        'getTimestampStatistics',
-        'createTimestamp',
-        'updateTimestamp',
-        'saveDayTimestamps',
-        'createDayClosing',
-        'deleteDayClosing',
-        'getDayClosingTillDate',
-        'createDayClosingsTillDate',
-        'setInitialBalance',
-        'getPauseConfigs',
-        'createPauseConfig',
-        'updatePauseConfig',
-        'deletePauseConfig',
-    ] as const;
-    if (!allowed.includes(operation as typeof allowed[number])) {
-        throw new NodeOperationError(this.getNode(), `Operation "${operation}" not supported by Timestamps.`);
-    }
-
-    const credentials = await this.getCredentials('tanssApi');
-    if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
-
-    const apiToken = this.getNodeParameter('apiToken', i, '') as string;
-    const typedCredentials = credentials as { baseURL?: string };
-    const baseURL = typedCredentials.baseURL;
-    if (!baseURL) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
-
-    // GET list
-    if (operation === 'getTimestamps') {
-        const from = this.getNodeParameter('from', i, 0) as number;
-        const till = this.getNodeParameter('till', i, 0) as number;
-
-        const params: string[] = [];
-        if (from && from > 0) params.push(`from=${encodeURIComponent(String(from))}`);
-        if (till && till > 0) params.push(`till=${encodeURIComponent(String(till))}`);
-
-        const query = params.length ? `?${params.join('&')}` : '';
-        const url = `${baseURL}/backend/api/v1/timestamps${query}`;
-
-        const requestOptions: IDataObject = {
-            method: 'GET',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            json: true,
-        };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to fetch timestamps: ${message}`);
-        }
-    }
-
-    // GET info
-    if (operation === 'getTimestampInfo') {
-        const from = this.getNodeParameter('from', i, 0) as number;
-        const till = this.getNodeParameter('till', i, 0) as number;
-
-        const params: string[] = [];
-        if (from && from > 0) params.push(`from=${encodeURIComponent(String(from))}`);
-        if (till && till > 0) params.push(`till=${encodeURIComponent(String(till))}`);
-
-        const query = params.length ? `?${params.join('&')}` : '';
-        const url = `${baseURL}/backend/api/v1/timestamps/info${query}`;
-
-        const requestOptions: IDataObject = {
-            method: 'GET',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            json: true,
-        };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to fetch timestamp info: ${message}`);
-        }
-    }
-
-    // GET statistics
-    if (operation === 'getTimestampStatistics') {
-        const from = this.getNodeParameter('from', i, 0) as number;
-        const till = this.getNodeParameter('till', i, 0) as number;
-        const employeeIds = this.getNodeParameter('employeeIds', i, '') as string;
-
-        const params: string[] = [];
-        if (from && from > 0) params.push(`from=${encodeURIComponent(String(from))}`);
-        if (till && till > 0) params.push(`till=${encodeURIComponent(String(till))}`);
-        if (employeeIds && employeeIds.trim() !== '') params.push(`employeeIds=${encodeURIComponent(employeeIds)}`);
-
-        const query = params.length ? `?${params.join('&')}` : '';
-        const url = `${baseURL}/backend/api/v1/timestamps/statistics${query}`;
-
-        const requestOptions: IDataObject = {
-            method: 'GET',
-            url,
-            headers: { apiToken, 'Content-Type': 'application/json' },
-            json: true,
-        };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to fetch timestamp statistics: ${message}`);
-        }
-    }
-
-    // CREATE
-    if (operation === 'createTimestamp') {
-        const autoPause = this.getNodeParameter('autoPause', i, false) as boolean;
-        const employeeId = this.getNodeParameter('employeeId', i, 0) as number;
-        const date = this.getNodeParameter('date', i, 0) as number;
-        const state = this.getNodeParameter('state', i, '') as string;
-        const type = this.getNodeParameter('type', i, '') as string;
-
-        if (!employeeId || employeeId <= 0) throw new NodeOperationError(this.getNode(), 'Valid employeeId is required.');
-        if (!date || date <= 0) throw new NodeOperationError(this.getNode(), 'Valid date (timestamp) is required.');
-        if (!state) throw new NodeOperationError(this.getNode(), 'State is required.');
-        if (!type) throw new NodeOperationError(this.getNode(), 'Type is required.');
-
-        const body: IDataObject = { employeeId, date, state, type };
-
-        const url = `${baseURL}/backend/api/v1/timestamps${autoPause ? '?autoPause=true' : ''}`;
-        const requestOptions: IDataObject = { method: 'POST', url, headers: { apiToken, 'Content-Type': 'application/json' }, body, json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to create timestamp: ${message}`);
-        }
-    }
-
-    // UPDATE single
-    if (operation === 'updateTimestamp') {
-        const timestampId = this.getNodeParameter('timestampId', i, 0) as number;
-        const employeeId = this.getNodeParameter('employeeId', i, 0) as number;
-        const date = this.getNodeParameter('date', i, 0) as number;
-        const state = this.getNodeParameter('state', i, '') as string;
-        const type = this.getNodeParameter('type', i, '') as string;
-
-        if (!timestampId || timestampId <= 0) throw new NodeOperationError(this.getNode(), 'Valid timestampId is required.');
-        if (!employeeId || employeeId <= 0) throw new NodeOperationError(this.getNode(), 'Valid employeeId is required.');
-        if (!date || date <= 0) throw new NodeOperationError(this.getNode(), 'Valid date (timestamp) is required.');
-        if (!state) throw new NodeOperationError(this.getNode(), 'State is required.');
-        if (!type) throw new NodeOperationError(this.getNode(), 'Type is required.');
-
-        const body: IDataObject = { employeeId, date, state, type };
-
-        const url = `${baseURL}/backend/api/v1/timestamps/${timestampId}`;
-        const requestOptions: IDataObject = { method: 'PUT', url, headers: { apiToken, 'Content-Type': 'application/json' }, body, json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to update timestamp: ${message}`);
-        }
-    }
-
-    // SAVE DAY (bulk)
-    if (operation === 'saveDayTimestamps') {
-        const employeeIdDay = this.getNodeParameter('employeeIdDay', i, 0) as number;
-        const day = this.getNodeParameter('day', i, '') as string;
-        const timestampsJson = this.getNodeParameter('timestampsJson', i, '[]') as string;
-
-        if (!employeeIdDay || employeeIdDay <= 0) throw new NodeOperationError(this.getNode(), 'Valid employeeId is required.');
-        if (!day) throw new NodeOperationError(this.getNode(), 'Day (YYYY-mm-dd) is required.');
-
-        let timestampsArray: unknown;
-        try {
-            timestampsArray = JSON.parse(timestampsJson);
-        } catch {
-            throw new NodeOperationError(this.getNode(), 'timestampsJson must be valid JSON.');
-        }
-        if (!Array.isArray(timestampsArray)) throw new NodeOperationError(this.getNode(), 'timestampsJson must be a JSON array.');
-
-        const url = `${baseURL}/backend/api/v1/timestamps/${employeeIdDay}/day/${encodeURIComponent(day)}`;
-        const requestOptions: IDataObject = { method: 'PUT', url, headers: { apiToken, 'Content-Type': 'application/json' }, body: timestampsArray as IDataObject[], json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to save day timestamps: ${message}`);
-        }
-    }
-
-    // CREATE Day Closing(s)
-    if (operation === 'createDayClosing') {
-        const dayClosingsJson = this.getNodeParameter('dayClosingsJson', i, '[]') as string;
-        let payload: unknown;
-        try {
-            payload = JSON.parse(dayClosingsJson);
-        } catch {
-            throw new NodeOperationError(this.getNode(), 'dayClosingsJson must be valid JSON.');
-        }
-        if (!Array.isArray(payload)) throw new NodeOperationError(this.getNode(), 'dayClosingsJson must be an array.');
-
-        for (const entry of payload) {
-            if (typeof entry !== 'object' || entry === null) throw new NodeOperationError(this.getNode(), 'Each day closing must be an object.');
-            const obj = entry as { employeeId?: number; date?: string };
-            if (!obj.employeeId || typeof obj.employeeId !== 'number' || obj.employeeId <= 0) throw new NodeOperationError(this.getNode(), 'Each day closing requires a valid employeeId.');
-            if (!obj.date || typeof obj.date !== 'string') throw new NodeOperationError(this.getNode(), 'Each day closing requires a valid date string (YYYY-mm-dd).');
-        }
-
-        const url = `${baseURL}/backend/api/v1/timestamps/dayClosing`;
-        const requestOptions: IDataObject = { method: 'POST', url, headers: { apiToken, 'Content-Type': 'application/json' }, body: payload as IDataObject[], json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to create day closing(s): ${message}`);
-        }
-    }
-
-    // DELETE Day Closing(s)
-    if (operation === 'deleteDayClosing') {
-        const dayClosingsJson = this.getNodeParameter('dayClosingsJson', i, '[]') as string;
-        let payload: unknown;
-        try {
-            payload = JSON.parse(dayClosingsJson);
-        } catch {
-            throw new NodeOperationError(this.getNode(), 'dayClosingsJson must be valid JSON.');
-        }
-        if (!Array.isArray(payload)) throw new NodeOperationError(this.getNode(), 'dayClosingsJson must be an array.');
-
-        for (const entry of payload) {
-            if (typeof entry !== 'object' || entry === null) throw new NodeOperationError(this.getNode(), 'Each day closing must be an object.');
-            const obj = entry as { employeeId?: number; date?: string };
-            if (!obj.employeeId || typeof obj.employeeId !== 'number' || obj.employeeId <= 0) throw new NodeOperationError(this.getNode(), 'Each day closing requires a valid employeeId.');
-            if (!obj.date || typeof obj.date !== 'string') throw new NodeOperationError(this.getNode(), 'Each day closing requires a valid date string (YYYY-mm-dd).');
-        }
-
-        const url = `${baseURL}/backend/api/v1/timestamps/dayClosing`;
-        const requestOptions: IDataObject = { method: 'DELETE', url, headers: { apiToken, 'Content-Type': 'application/json' }, body: payload as IDataObject[], json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to delete day closing(s): ${message}`);
-        }
-    }
-
-    // GET dayClosing tillDate
-    if (operation === 'getDayClosingTillDate') {
-        const url = `${baseURL}/backend/api/v1/timestamps/dayClosing/tillDate`;
-        const requestOptions: IDataObject = { method: 'GET', url, headers: { apiToken, 'Content-Type': 'application/json' }, json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to fetch day closing till date: ${message}`);
-        }
-    }
-
-    // CREATE Day Closings Till Date
-    if (operation === 'createDayClosingsTillDate') {
-        const tillDate = this.getNodeParameter('tillDate', i, '') as string;
-        const employeeIdsJson = this.getNodeParameter('employeeIdsJson', i, '[]') as string;
-
-        if (!tillDate) throw new NodeOperationError(this.getNode(), 'tillDate is required.');
-        let employeeIds: unknown;
-        try {
-            employeeIds = JSON.parse(employeeIdsJson);
-        } catch {
-            throw new NodeOperationError(this.getNode(), 'employeeIdsJson must be valid JSON array.');
-        }
-        if (!Array.isArray(employeeIds)) throw new NodeOperationError(this.getNode(), 'employeeIdsJson must be an array of integers.');
-
-        const url = `${baseURL}/backend/api/v1/timestamps/dayClosing/tillDate`;
-        const requestOptions: IDataObject = { method: 'POST', url, headers: { apiToken, 'Content-Type': 'application/json' }, body: { tillDate, employeeIds: employeeIds as number[] }, json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to create day closings till date: ${message}`);
-        }
-    }
-
-    // SET initial balance
-    if (operation === 'setInitialBalance') {
-        const employeeIdInitial = this.getNodeParameter('employeeIdInitial', i, 0) as number;
-        const initialBalance = this.getNodeParameter('initialBalance', i, 0) as number;
-
-        if (!employeeIdInitial || employeeIdInitial <= 0) throw new NodeOperationError(this.getNode(), 'Valid employeeId is required.');
-        if (typeof initialBalance !== 'number') throw new NodeOperationError(this.getNode(), 'initialBalance must be a number.');
-
-        const url = `${baseURL}/backend/api/v1/timestamps/employee/${employeeIdInitial}/initialBalance`;
-        const requestOptions: IDataObject = { method: 'POST', url, headers: { apiToken, 'Content-Type': 'application/json' }, body: { balance: initialBalance }, json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to set initial balance: ${message}`);
-        }
-    }
-
-    // GET pause configs
-    if (operation === 'getPauseConfigs') {
-        const url = `${baseURL}/backend/api/v1/timestamps/pauseConfigs`;
-        const requestOptions: IDataObject = { method: 'GET', url, headers: { apiToken, 'Content-Type': 'application/json' }, json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to fetch pause configs: ${message}`);
-        }
-    }
-
-    // CREATE pause config
-    if (operation === 'createPauseConfig') {
-        const fromMinutes = this.getNodeParameter('fromMinutes', i, 0) as number;
-        const minimumPause = this.getNodeParameter('minimumPause', i, 0) as number;
-
-        if (typeof fromMinutes !== 'number') throw new NodeOperationError(this.getNode(), 'fromMinutes must be a number.');
-        if (typeof minimumPause !== 'number') throw new NodeOperationError(this.getNode(), 'minimumPause must be a number.');
-
-        const url = `${baseURL}/backend/api/v1/timestamps/pauseConfigs`;
-        const requestOptions: IDataObject = { method: 'POST', url, headers: { apiToken, 'Content-Type': 'application/json' }, body: { fromMinutes, minimumPause }, json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to create pause config: ${message}`);
-        }
-    }
-
-    // UPDATE pause config
-    if (operation === 'updatePauseConfig') {
-        const pauseConfigId = this.getNodeParameter('pauseConfigId', i, 0) as number;
-        const fromMinutes = this.getNodeParameter('fromMinutes', i, 0) as number;
-        const minimumPause = this.getNodeParameter('minimumPause', i, 0) as number;
-
-        if (!pauseConfigId || pauseConfigId <= 0) throw new NodeOperationError(this.getNode(), 'Valid pauseConfigId is required.');
-        if (typeof fromMinutes !== 'number') throw new NodeOperationError(this.getNode(), 'fromMinutes must be a number.');
-        if (typeof minimumPause !== 'number') throw new NodeOperationError(this.getNode(), 'minimumPause must be a number.');
-
-        const url = `${baseURL}/backend/api/v1/timestamps/pauseConfigs/${pauseConfigId}`;
-        const requestOptions: IDataObject = { method: 'PUT', url, headers: { apiToken, 'Content-Type': 'application/json' }, body: { fromMinutes, minimumPause }, json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to update pause config: ${message}`);
-        }
-    }
-
-    // DELETE pause config
-    if (operation === 'deletePauseConfig') {
-        const pauseConfigId = this.getNodeParameter('pauseConfigId', i, 0) as number;
-        if (!pauseConfigId || pauseConfigId <= 0) throw new NodeOperationError(this.getNode(), 'Valid pauseConfigId is required.');
-
-        const url = `${baseURL}/backend/api/v1/timestamps/pauseConfigs/${pauseConfigId}`;
-        const requestOptions: IDataObject = { method: 'DELETE', url, headers: { apiToken, 'Content-Type': 'application/json' }, json: true };
-
-        try {
-            const response = await this.helpers.httpRequest(requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions);
-            return response;
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-            throw new NodeOperationError(this.getNode(), `Failed to delete pause config: ${message}`);
-        }
-    }
-
-    throw new NodeOperationError(this.getNode(), 'Unhandled operation');
+	const operation = this.getNodeParameter('operation', i) as string;
+	const allowed = [
+		'getTimestamps',
+		'getTimestampInfo',
+		'getTimestampStatistics',
+		'createTimestamp',
+		'updateTimestamp',
+		'saveDayTimestamps',
+		'createDayClosing',
+		'deleteDayClosing',
+		'getDayClosingTillDate',
+		'createDayClosingsTillDate',
+		'setInitialBalance',
+		'getPauseConfigs',
+		'createPauseConfig',
+		'updatePauseConfig',
+		'deletePauseConfig',
+	] as const;
+	if (!allowed.includes(operation as (typeof allowed)[number])) {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Operation "${operation}" not supported by Timestamps.`,
+		);
+	}
+
+	const credentials = await this.getCredentials('tanssApi');
+	if (!credentials) throw new NodeOperationError(this.getNode(), 'No credentials returned!');
+
+	const apiToken = this.getNodeParameter('apiToken', i, '') as string;
+	const typedCredentials = credentials as { baseURL?: string };
+	const baseURL = typedCredentials.baseURL;
+	if (!baseURL) throw new NodeOperationError(this.getNode(), 'No baseURL in credentials');
+
+	// GET list
+	if (operation === 'getTimestamps') {
+		const from = this.getNodeParameter('from', i, 0) as number;
+		const till = this.getNodeParameter('till', i, 0) as number;
+
+		const params: string[] = [];
+		if (from && from > 0) params.push(`from=${encodeURIComponent(String(from))}`);
+		if (till && till > 0) params.push(`till=${encodeURIComponent(String(till))}`);
+
+		const query = params.length ? `?${params.join('&')}` : '';
+		const url = `${baseURL}/backend/api/v1/timestamps${query}`;
+
+		const requestOptions: IDataObject = {
+			method: 'GET',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to fetch timestamps: ${message}`);
+		}
+	}
+
+	// GET info
+	if (operation === 'getTimestampInfo') {
+		const from = this.getNodeParameter('from', i, 0) as number;
+		const till = this.getNodeParameter('till', i, 0) as number;
+
+		const params: string[] = [];
+		if (from && from > 0) params.push(`from=${encodeURIComponent(String(from))}`);
+		if (till && till > 0) params.push(`till=${encodeURIComponent(String(till))}`);
+
+		const query = params.length ? `?${params.join('&')}` : '';
+		const url = `${baseURL}/backend/api/v1/timestamps/info${query}`;
+
+		const requestOptions: IDataObject = {
+			method: 'GET',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to fetch timestamp info: ${message}`);
+		}
+	}
+
+	// GET statistics
+	if (operation === 'getTimestampStatistics') {
+		const from = this.getNodeParameter('from', i, 0) as number;
+		const till = this.getNodeParameter('till', i, 0) as number;
+		const employeeIds = this.getNodeParameter('employeeIds', i, '') as string;
+
+		const params: string[] = [];
+		if (from && from > 0) params.push(`from=${encodeURIComponent(String(from))}`);
+		if (till && till > 0) params.push(`till=${encodeURIComponent(String(till))}`);
+		if (employeeIds && employeeIds.trim() !== '')
+			params.push(`employeeIds=${encodeURIComponent(employeeIds)}`);
+
+		const query = params.length ? `?${params.join('&')}` : '';
+		const url = `${baseURL}/backend/api/v1/timestamps/statistics${query}`;
+
+		const requestOptions: IDataObject = {
+			method: 'GET',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to fetch timestamp statistics: ${message}`,
+			);
+		}
+	}
+
+	// CREATE
+	if (operation === 'createTimestamp') {
+		const autoPause = this.getNodeParameter('autoPause', i, false) as boolean;
+		const employeeId = this.getNodeParameter('employeeId', i, 0) as number;
+		const date = this.getNodeParameter('date', i, 0) as number;
+		const state = this.getNodeParameter('state', i, '') as string;
+		const type = this.getNodeParameter('type', i, '') as string;
+
+		if (!employeeId || employeeId <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid employeeId is required.');
+		if (!date || date <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid date (timestamp) is required.');
+		if (!state) throw new NodeOperationError(this.getNode(), 'State is required.');
+		if (!type) throw new NodeOperationError(this.getNode(), 'Type is required.');
+
+		const body: IDataObject = { employeeId, date, state, type };
+
+		const url = `${baseURL}/backend/api/v1/timestamps${autoPause ? '?autoPause=true' : ''}`;
+		const requestOptions: IDataObject = {
+			method: 'POST',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to create timestamp: ${message}`);
+		}
+	}
+
+	// UPDATE single
+	if (operation === 'updateTimestamp') {
+		const timestampId = this.getNodeParameter('timestampId', i, 0) as number;
+		const employeeId = this.getNodeParameter('employeeId', i, 0) as number;
+		const date = this.getNodeParameter('date', i, 0) as number;
+		const state = this.getNodeParameter('state', i, '') as string;
+		const type = this.getNodeParameter('type', i, '') as string;
+
+		if (!timestampId || timestampId <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid timestampId is required.');
+		if (!employeeId || employeeId <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid employeeId is required.');
+		if (!date || date <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid date (timestamp) is required.');
+		if (!state) throw new NodeOperationError(this.getNode(), 'State is required.');
+		if (!type) throw new NodeOperationError(this.getNode(), 'Type is required.');
+
+		const body: IDataObject = { employeeId, date, state, type };
+
+		const url = `${baseURL}/backend/api/v1/timestamps/${timestampId}`;
+		const requestOptions: IDataObject = {
+			method: 'PUT',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body,
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to update timestamp: ${message}`);
+		}
+	}
+
+	// SAVE DAY (bulk)
+	if (operation === 'saveDayTimestamps') {
+		const employeeIdDay = this.getNodeParameter('employeeIdDay', i, 0) as number;
+		const day = this.getNodeParameter('day', i, '') as string;
+		const timestampsJson = this.getNodeParameter('timestampsJson', i, '[]') as string;
+
+		if (!employeeIdDay || employeeIdDay <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid employeeId is required.');
+		if (!day) throw new NodeOperationError(this.getNode(), 'Day (YYYY-mm-dd) is required.');
+
+		let timestampsArray: unknown;
+		try {
+			timestampsArray = JSON.parse(timestampsJson);
+		} catch {
+			throw new NodeOperationError(this.getNode(), 'timestampsJson must be valid JSON.');
+		}
+		if (!Array.isArray(timestampsArray))
+			throw new NodeOperationError(this.getNode(), 'timestampsJson must be a JSON array.');
+
+		const url = `${baseURL}/backend/api/v1/timestamps/${employeeIdDay}/day/${encodeURIComponent(day)}`;
+		const requestOptions: IDataObject = {
+			method: 'PUT',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body: timestampsArray as IDataObject[],
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to save day timestamps: ${message}`);
+		}
+	}
+
+	// CREATE Day Closing(s)
+	if (operation === 'createDayClosing') {
+		const dayClosingsJson = this.getNodeParameter('dayClosingsJson', i, '[]') as string;
+		let payload: unknown;
+		try {
+			payload = JSON.parse(dayClosingsJson);
+		} catch {
+			throw new NodeOperationError(this.getNode(), 'dayClosingsJson must be valid JSON.');
+		}
+		if (!Array.isArray(payload))
+			throw new NodeOperationError(this.getNode(), 'dayClosingsJson must be an array.');
+
+		for (const entry of payload) {
+			if (typeof entry !== 'object' || entry === null)
+				throw new NodeOperationError(this.getNode(), 'Each day closing must be an object.');
+			const obj = entry as { employeeId?: number; date?: string };
+			if (!obj.employeeId || typeof obj.employeeId !== 'number' || obj.employeeId <= 0)
+				throw new NodeOperationError(
+					this.getNode(),
+					'Each day closing requires a valid employeeId.',
+				);
+			if (!obj.date || typeof obj.date !== 'string')
+				throw new NodeOperationError(
+					this.getNode(),
+					'Each day closing requires a valid date string (YYYY-mm-dd).',
+				);
+		}
+
+		const url = `${baseURL}/backend/api/v1/timestamps/dayClosing`;
+		const requestOptions: IDataObject = {
+			method: 'POST',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body: payload as IDataObject[],
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to create day closing(s): ${message}`);
+		}
+	}
+
+	// DELETE Day Closing(s)
+	if (operation === 'deleteDayClosing') {
+		const dayClosingsJson = this.getNodeParameter('dayClosingsJson', i, '[]') as string;
+		let payload: unknown;
+		try {
+			payload = JSON.parse(dayClosingsJson);
+		} catch {
+			throw new NodeOperationError(this.getNode(), 'dayClosingsJson must be valid JSON.');
+		}
+		if (!Array.isArray(payload))
+			throw new NodeOperationError(this.getNode(), 'dayClosingsJson must be an array.');
+
+		for (const entry of payload) {
+			if (typeof entry !== 'object' || entry === null)
+				throw new NodeOperationError(this.getNode(), 'Each day closing must be an object.');
+			const obj = entry as { employeeId?: number; date?: string };
+			if (!obj.employeeId || typeof obj.employeeId !== 'number' || obj.employeeId <= 0)
+				throw new NodeOperationError(
+					this.getNode(),
+					'Each day closing requires a valid employeeId.',
+				);
+			if (!obj.date || typeof obj.date !== 'string')
+				throw new NodeOperationError(
+					this.getNode(),
+					'Each day closing requires a valid date string (YYYY-mm-dd).',
+				);
+		}
+
+		const url = `${baseURL}/backend/api/v1/timestamps/dayClosing`;
+		const requestOptions: IDataObject = {
+			method: 'DELETE',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body: payload as IDataObject[],
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to delete day closing(s): ${message}`);
+		}
+	}
+
+	// GET dayClosing tillDate
+	if (operation === 'getDayClosingTillDate') {
+		const url = `${baseURL}/backend/api/v1/timestamps/dayClosing/tillDate`;
+		const requestOptions: IDataObject = {
+			method: 'GET',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to fetch day closing till date: ${message}`,
+			);
+		}
+	}
+
+	// CREATE Day Closings Till Date
+	if (operation === 'createDayClosingsTillDate') {
+		const tillDate = this.getNodeParameter('tillDate', i, '') as string;
+		const employeeIdsJson = this.getNodeParameter('employeeIdsJson', i, '[]') as string;
+
+		if (!tillDate) throw new NodeOperationError(this.getNode(), 'tillDate is required.');
+		let employeeIds: unknown;
+		try {
+			employeeIds = JSON.parse(employeeIdsJson);
+		} catch {
+			throw new NodeOperationError(this.getNode(), 'employeeIdsJson must be valid JSON array.');
+		}
+		if (!Array.isArray(employeeIds))
+			throw new NodeOperationError(this.getNode(), 'employeeIdsJson must be an array of integers.');
+
+		const url = `${baseURL}/backend/api/v1/timestamps/dayClosing/tillDate`;
+		const requestOptions: IDataObject = {
+			method: 'POST',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body: { tillDate, employeeIds: employeeIds as number[] },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(
+				this.getNode(),
+				`Failed to create day closings till date: ${message}`,
+			);
+		}
+	}
+
+	// SET initial balance
+	if (operation === 'setInitialBalance') {
+		const employeeIdInitial = this.getNodeParameter('employeeIdInitial', i, 0) as number;
+		const initialBalance = this.getNodeParameter('initialBalance', i, 0) as number;
+
+		if (!employeeIdInitial || employeeIdInitial <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid employeeId is required.');
+		if (typeof initialBalance !== 'number')
+			throw new NodeOperationError(this.getNode(), 'initialBalance must be a number.');
+
+		const url = `${baseURL}/backend/api/v1/timestamps/employee/${employeeIdInitial}/initialBalance`;
+		const requestOptions: IDataObject = {
+			method: 'POST',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body: { balance: initialBalance },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to set initial balance: ${message}`);
+		}
+	}
+
+	// GET pause configs
+	if (operation === 'getPauseConfigs') {
+		const url = `${baseURL}/backend/api/v1/timestamps/pauseConfigs`;
+		const requestOptions: IDataObject = {
+			method: 'GET',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to fetch pause configs: ${message}`);
+		}
+	}
+
+	// CREATE pause config
+	if (operation === 'createPauseConfig') {
+		const fromMinutes = this.getNodeParameter('fromMinutes', i, 0) as number;
+		const minimumPause = this.getNodeParameter('minimumPause', i, 0) as number;
+
+		if (typeof fromMinutes !== 'number')
+			throw new NodeOperationError(this.getNode(), 'fromMinutes must be a number.');
+		if (typeof minimumPause !== 'number')
+			throw new NodeOperationError(this.getNode(), 'minimumPause must be a number.');
+
+		const url = `${baseURL}/backend/api/v1/timestamps/pauseConfigs`;
+		const requestOptions: IDataObject = {
+			method: 'POST',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body: { fromMinutes, minimumPause },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to create pause config: ${message}`);
+		}
+	}
+
+	// UPDATE pause config
+	if (operation === 'updatePauseConfig') {
+		const pauseConfigId = this.getNodeParameter('pauseConfigId', i, 0) as number;
+		const fromMinutes = this.getNodeParameter('fromMinutes', i, 0) as number;
+		const minimumPause = this.getNodeParameter('minimumPause', i, 0) as number;
+
+		if (!pauseConfigId || pauseConfigId <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid pauseConfigId is required.');
+		if (typeof fromMinutes !== 'number')
+			throw new NodeOperationError(this.getNode(), 'fromMinutes must be a number.');
+		if (typeof minimumPause !== 'number')
+			throw new NodeOperationError(this.getNode(), 'minimumPause must be a number.');
+
+		const url = `${baseURL}/backend/api/v1/timestamps/pauseConfigs/${pauseConfigId}`;
+		const requestOptions: IDataObject = {
+			method: 'PUT',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			body: { fromMinutes, minimumPause },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to update pause config: ${message}`);
+		}
+	}
+
+	// DELETE pause config
+	if (operation === 'deletePauseConfig') {
+		const pauseConfigId = this.getNodeParameter('pauseConfigId', i, 0) as number;
+		if (!pauseConfigId || pauseConfigId <= 0)
+			throw new NodeOperationError(this.getNode(), 'Valid pauseConfigId is required.');
+
+		const url = `${baseURL}/backend/api/v1/timestamps/pauseConfigs/${pauseConfigId}`;
+		const requestOptions: IDataObject = {
+			method: 'DELETE',
+			url,
+			headers: { apiToken, 'Content-Type': 'application/json' },
+			json: true,
+		};
+
+		try {
+			const response = await this.helpers.httpRequest(
+				requestOptions as unknown as import('n8n-workflow').IHttpRequestOptions,
+			);
+			return response;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(this.getNode(), `Failed to delete pause config: ${message}`);
+		}
+	}
+
+	throw new NodeOperationError(this.getNode(), 'Unhandled operation');
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
         "dev": "n8n-node dev",
         "lint": "n8n-node lint",
         "lint:fix": "n8n-node lint --fix",
+        "format": "prettier --check .",
+        "format:fix": "prettier --write .",
         "release": "n8n-node release",
         "prepublishOnly": "n8n-node prerelease"
     },


### PR DESCRIPTION
# Add Prettier scripts and CI format check, and reformat code

Hiy,

this PR makes formatting consistent and adds an easy workflow for it.

## **Changes:**

* Add `npm run format` and `npm run format:fix` (Prettier check and auto-fix).
* Add a `.prettierignore` file to avoid formatting generated files and other non-source files.
* Update CI to run `npm run format` so PRs fail if formatting is not consistent.
* Reformat the node and submodules once to match the existing Prettier config.

## **Why:**

Right now the code style is mixed. Some files are formatted and others are not. This makes reviews harder and creates noisy diffs. With these changes, contributors can run one command to check formatting, and CI will enforce the same rules. This makes collaboration on the code easier and more reliable.

## **How to use:**

* Check formatting: `npm run format`
* Fix formatting: `npm run format:fix`


