### PR TITLE
chore/add devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"name": "node-dev",
+	"image": "docker.io/library/node:24-trixie",
+	"workspaceFolder": "/workspace",
+	"remoteUser": "node",
+	"updateRemoteUserUID": false,
+	"mounts": ["source=${localWorkspaceFolder},target=/workspace,type=bind"],
+	"customizations": {
+		"vscode": {
+			"extensions": ["prettier.prettier-vscode"]
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -485,3 +485,9 @@ Tested with TANSS API. Version: 10.10.0
 
 * [n8n community nodes documentation](https://docs.n8n.io/integrations/#community-nodes)
 * [Tanss API documentation](https://api-doc.tanss.de/)
+
+## Development
+
+This project can be developed using a regular local Node.js setup.
+
+Optionally, a dev container configuration is included to provide a ready-to-use development environment with the required Node.js version and basic editor tooling.


### PR DESCRIPTION
# Add optional dev container for Node.js development

Hi,

this PR adds an optional dev container configuration for local development and documents its usage in the README.

## **Changes:**

* Add a VS Code dev container configuration using an official Node.js image.
* Document the development setup and the optional dev container in the README.

## **Notes:**

Using the dev container is completely optional. The project can still be developed with a regular local Node.js setup, and no build or CI logic depends on the dev container.

The goal is simply to make it easier to get a consistent development environment without imposing any specific workflow.
