### PR TITLE
Fix refresh token handling for user credentials

### DIFF
--- a/credentials/TanssUserApi.credentials.ts
+++ b/credentials/TanssUserApi.credentials.ts
@@ -85,7 +85,7 @@ async function refreshWithRefreshToken(
 	return extractTokens(response);
 }
 
-async function getFreshUserTokens(
+export async function getFreshUserTokens(
 	helper: IHttpRequestHelper,
 	credentials: ICredentialDataDecryptedObject,
 ): Promise<{ apiToken: string; refreshToken: string }> {

--- a/nodes/tanss/sub/request.ts
+++ b/nodes/tanss/sub/request.ts
@@ -1,14 +1,34 @@
-import { IExecuteFunctions, IHttpRequestOptions, NodeOperationError } from 'n8n-workflow';
+import {
+	IAdditionalCredentialOptions,
+	ICredentialDataDecryptedObject,
+	IExecuteFunctions,
+	IHttpRequestOptions,
+	NodeOperationError,
+} from 'n8n-workflow';
 
 export type TanssAuthMode = 'user' | 'generated';
+type TanssCredentialName = 'tanssUserApi' | 'tanssGeneratedTokenApi';
 
 export function getTanssAuthMode(this: IExecuteFunctions, itemIndex: number): TanssAuthMode {
 	return this.getNodeParameter('authMode', itemIndex, 'user') as TanssAuthMode;
 }
 
+function getTanssCredentialName(this: IExecuteFunctions, itemIndex: number): TanssCredentialName {
+	const attachedCredentials = this.getNode().credentials;
+
+	if (attachedCredentials?.tanssUserApi) {
+		return 'tanssUserApi';
+	}
+
+	if (attachedCredentials?.tanssGeneratedTokenApi) {
+		return 'tanssGeneratedTokenApi';
+	}
+
+	return getTanssAuthMode.call(this, itemIndex) === 'generated' ? 'tanssGeneratedTokenApi' : 'tanssUserApi';
+}
+
 export async function getTanssBaseUrl(this: IExecuteFunctions, itemIndex: number): Promise<string> {
-	const authMode = getTanssAuthMode.call(this, itemIndex);
-	const credentialName = authMode === 'generated' ? 'tanssGeneratedTokenApi' : 'tanssUserApi';
+	const credentialName = getTanssCredentialName.call(this, itemIndex);
 	const credentials = await this.getCredentials(credentialName);
 	const baseURL = String(credentials.baseURL ?? '').replace(/\/+$/, '');
 
@@ -20,11 +40,90 @@ export async function getTanssBaseUrl(this: IExecuteFunctions, itemIndex: number
 }
 
 export function isGeneratedTokenMode(this: IExecuteFunctions, itemIndex: number): boolean {
-	return getTanssAuthMode.call(this, itemIndex) === 'generated';
+	return getTanssCredentialName.call(this, itemIndex) === 'tanssGeneratedTokenApi';
+}
+
+function shouldRetryExpiredUserToken(error: unknown): boolean {
+	const candidate = error as {
+		httpCode?: string | number;
+		message?: string;
+		description?: string;
+		context?: {
+			data?: {
+				error?: { tokenExceptionType?: string; text?: string; message?: string };
+				message?: string;
+			};
+		};
+		response?: {
+			status?: number;
+			statusCode?: number;
+			data?: {
+				error?: { tokenExceptionType?: string; text?: string; message?: string };
+				message?: string;
+			};
+			body?: {
+				error?: { tokenExceptionType?: string; text?: string; message?: string };
+				message?: string;
+			};
+		};
+	};
+
+	const statusCode =
+		candidate.response?.status ??
+		candidate.response?.statusCode ??
+		(typeof candidate.httpCode === 'string' ? Number(candidate.httpCode) : candidate.httpCode);
+
+	if (statusCode !== 403) {
+		return false;
+	}
+
+	const errorData = candidate.response?.data ?? candidate.response?.body ?? candidate.context?.data;
+	const tokenExceptionType = errorData?.error?.tokenExceptionType;
+	const tokenText = errorData?.error?.text;
+	const tokenMessage = errorData?.error?.message ?? errorData?.message;
+	const fallbackText = `${candidate.message ?? ''} ${candidate.description ?? ''}`;
+
+	return [tokenExceptionType, tokenText, tokenMessage, fallbackText].some(
+		(value) =>
+			String(value ?? '')
+				.toUpperCase()
+				.includes('TOKEN_HAS_EXPIRED') ||
+			String(value ?? '')
+				.toUpperCase()
+				.includes('EXPIRED'),
+	);
+}
+
+function getExpiredUserTokenRetryOptions(credentials: ICredentialDataDecryptedObject): IAdditionalCredentialOptions {
+	return {
+		credentialsDecrypted: {
+			id: '',
+			name: 'tanssUserApi',
+			type: 'tanssUserApi',
+			data: {
+				...credentials,
+				apiToken: '',
+			},
+		},
+	};
 }
 
 export async function tanssHttpRequest(this: IExecuteFunctions, itemIndex: number, options: IHttpRequestOptions) {
-	const authMode = getTanssAuthMode.call(this, itemIndex);
-	const credentialName = authMode === 'generated' ? 'tanssGeneratedTokenApi' : 'tanssUserApi';
-	return await this.helpers.httpRequestWithAuthentication.call(this, credentialName, options);
+	const credentialName = getTanssCredentialName.call(this, itemIndex);
+
+	if (credentialName === 'tanssGeneratedTokenApi') {
+		return await this.helpers.httpRequestWithAuthentication.call(this, credentialName, options);
+	}
+
+	try {
+		return await this.helpers.httpRequestWithAuthentication.call(this, credentialName, options);
+	} catch (error) {
+		if (!shouldRetryExpiredUserToken(error)) {
+			throw error;
+		}
+
+		const credentials = await this.getCredentials(credentialName, itemIndex);
+
+		return await this.helpers.httpRequestWithAuthentication.call(this, credentialName, options, getExpiredUserTokenRetryOptions(credentials));
+	}
 }


### PR DESCRIPTION
## Summary
Fix refresh token handling for TANSS user credentials by resolving the active credential type from the attached node credentials and retrying once when an expired user token returns `403`.

## Changes
- resolve the effective TANSS credential type from the node's attached credentials
- keep generated-token requests on the normal authenticated request path
- retry TANSS user requests once with a cleared `apiToken` when the API reports an expired token
- export `getFreshUserTokens` for reuse from the credential module

Closes #21